### PR TITLE
Fixing maximum crawl time

### DIFF
--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -653,7 +653,7 @@ public class Crawler implements Runnable {
 	 */
 	private boolean checkConstraints() {
 		long timePassed = System.currentTimeMillis() - controller.getSession().getStartTime();
-		long maxCrawlTime = configurationReader.getCrawlSpecificationReader().getMaximumRunTime();
+		long maxCrawlTime = configurationReader.getCrawlSpecificationReader().getMaximumRunTime() + controller.getSession().getStartTime();
 		if ((maxCrawlTime != 0) && (timePassed > maxCrawlTime)) {
 
 			LOGGER.info("Max time " + TimeUnit.MILLISECONDS.toSeconds(maxCrawlTime)


### PR DESCRIPTION
The maximum crawl time should be the maximum time specified by the user for the run time from the beginning of the crawling time (which I have added). The previous code, did not add the time when the crawl had started and therefore, it will always go into the if statement where it compares time elapsed with the maximum crawl time and only crawl a few states whereas I (the user) have defined more states, i.e. Max_States = 10.
