### PR TITLE
Fixed (or found the reason): Issue # 75

### DIFF
--- a/core/src/test/java/com/crawljax/core/CrawlerExecutorTest.java
+++ b/core/src/test/java/com/crawljax/core/CrawlerExecutorTest.java
@@ -28,7 +28,19 @@ public class CrawlerExecutorTest {
 		        new CrawlerExecutor(new BrowserConfiguration(BrowserType.firefox, 2));
 		TestThread t1 = new TestThread("Thread 1 Crawler 1", "");
 		TestThread t2 = new TestThread("Thread 2 Crawler 2 (Automatic)", "Automatic");
+		
 		executor.execute(t1);
+		/**
+		 * Slight delay between ThreadPoolExecutor.execute() is needed for this test to function correctly.
+		 * Depending on how the OS assigns JAVA threads to cores (or OS threads), 
+		 * the speed of execution of the methods could differ from the actual order of calling them. 
+		 * As a result, sometimes this test fails when executor.execute(t2) is actually executed
+		 * before executor.execute(t1).
+		 * There are only two ways to fix this. First is to put a small delay (as Thread.sleep(1)) between
+		 * method calling. Or assign only one core to JAVA SE process on Windows Task Manager (or equivalent
+		 * features of other OS).
+		 */
+		Thread.sleep(1);
 		executor.execute(t2);
 
 		executor.waitForTermination();


### PR DESCRIPTION
Found the reason behind the issue # 75. It's the OS assigning threads to different cores which sometimes run at different speeds momentarily. There are two ways to fix this. First is to put a small delay between method calling (in the test) in order to ensure that the first calling of the method gets executed first. The second way is to assign only one core to JAVA SE process on Windows Task Manager manually. Currently just added Thread.sleep(1) between method callings (between executor.execute(t1) and executor.execute(t2)).

This is just a minor commit I did while doing our project (EECE 310 Project). Hope this helps.
