### PR TITLE
Implemented issue #93 - "Manually Specify Paths"

### DIFF
--- a/core/src/main/java/com/crawljax/browser/BrowserPool.java
+++ b/core/src/main/java/com/crawljax/browser/BrowserPool.java
@@ -193,18 +193,28 @@ public final class BrowserPool {
 				}
 				for (EmbeddedBrowser b : available) {
 					try {
-						b.close();
+						// only close browser when we are in the end of URL list
+						if (configuration.getLastURLIndex() == configuration.getUrlListSize()-1){
+							b.close();
+						}
 					} finally {
-						deleteList.add(b);
+						if (configuration.getLastURLIndex() == configuration.getUrlListSize()-1){
+							deleteList.add(b);
+						}
 					}
 				}
 				available.removeAll(deleteList);
 				deleteList = new LinkedList<EmbeddedBrowser>();
 				for (EmbeddedBrowser b : taken) {
 					try {
-						b.close();
+						// only close browser when we are in the end of URL list
+						if (configuration.getLastURLIndex() == configuration.getUrlListSize()-1){
+							b.close();
+						}
 					} finally {
-						deleteList.add(b);
+						if (configuration.getLastURLIndex() == configuration.getUrlListSize()-1){
+							deleteList.add(b);
+						}
 					}
 				}
 				taken.removeAll(deleteList);

--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -168,7 +168,7 @@ public class Crawler implements Runnable {
 	/**
 	 * Brings the browser to the initial state.
 	 */
-	public void goToInitialURL() {
+	public void goToInitialURL() {	
 		LOG.info("Loading Page {}", config.getUrl());
 		getBrowser().goToUrl(config.getUrl());
 		controller.doBrowserWait(getBrowser());

--- a/core/src/main/java/com/crawljax/core/configuration/CrawlRules.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawlRules.java
@@ -37,12 +37,12 @@ public class CrawlRules {
 			crawlActionsBuilder = new CrawlActionsBuilder();
 			preCrawlConfig = PreCrawlConfiguration.builder();
 		}
-
+		
 		public CrawlRulesBuilder insertRandomDataInInputForms(boolean insertRandomData) {
 			crawlRules.randomInputInForms = insertRandomData;
 			return this;
 		}
-
+		
 		/**
 		 * @param frame
 		 *            A frame that should be excluded from the DOM, before doing any other

--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
@@ -29,7 +30,8 @@ public final class CrawljaxConfiguration {
 		private CrawljaxConfigurationBuilder(URL url) {
 			Preconditions.checkNotNull(url);
 			config = new CrawljaxConfiguration();
-			config.url = url;
+			config.urls = new ArrayList<URL>();
+			config.urls.add(url);
 		}
 
 		/**
@@ -137,6 +139,19 @@ public final class CrawljaxConfiguration {
 			config.crawlRules = crawlRules.build();
 			return config;
 		}
+		
+		public void alsoCrawl(String url){
+			try {
+				config.addUrlToList(new URL(url));
+			} catch (MalformedURLException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		public void alsoCrawl(URL url){
+			Preconditions.checkNotNull(url, "URL was null");
+			config.addUrlToList(url);
+		}
 
 	}
 
@@ -163,7 +178,8 @@ public final class CrawljaxConfiguration {
 		}
 	}
 
-	private URL url;
+	private ArrayList<URL> urls;
+	private int lastIndexURL = 0;
 
 	private BrowserConfiguration browserConfig = new BrowserConfiguration(BrowserType.firefox);
 	private Plugins plugins;
@@ -177,9 +193,33 @@ public final class CrawljaxConfiguration {
 
 	private CrawljaxConfiguration() {
 	}
-
-	public URL getUrl() {
-		return url;
+	
+	public int getUrlListSize(){
+		return this.urls.size();
+	}
+	
+	public int getLastURLIndex(){
+		return this.lastIndexURL;
+	}
+	
+	public boolean endOfURLArray(){
+	   if (this.lastIndexURL == getUrlListSize()){
+	      return true;
+	   } else {
+	      return false;
+	    }
+	  }
+	
+	public URL getUrl(){
+		return urls.get(this.lastIndexURL);
+	}
+	
+	private void addUrlToList(URL url_new){
+		this.urls.add(url_new);
+	}
+	
+	public void updateLastIndexURL(){
+		this.lastIndexURL++;
 	}
 
 	public BrowserConfiguration getBrowserConfig() {
@@ -223,12 +263,14 @@ public final class CrawljaxConfiguration {
 		result =
 		        prime * result
 		                + ((proxyConfiguration == null) ? 0 : proxyConfiguration.hashCode());
-		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		result = prime * result + ((this.urls.get(this.lastIndexURL) == null) ? 0 : this.urls.get(this.lastIndexURL).hashCode());
 		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
+		URL url = this.urls.get(this.lastIndexURL);
+		
 		if (this == obj) {
 			return true;
 		}
@@ -277,10 +319,10 @@ public final class CrawljaxConfiguration {
 			return false;
 		}
 		if (url == null) {
-			if (other.url != null) {
+			if (other.urls.get(other.lastIndexURL) != null) {
 				return false;
 			}
-		} else if (!url.equals(other.url)) {
+		} else if (!url.equals(other.urls.get(other.lastIndexURL))) {
 			return false;
 		}
 		return true;
@@ -290,7 +332,7 @@ public final class CrawljaxConfiguration {
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("CrawljaxConfiguration [url=");
-		builder.append(url);
+		builder.append(this.urls.get(this.lastIndexURL));
 		builder.append(", browserConfig=");
 		builder.append(browserConfig);
 		builder.append(", plugins=");

--- a/core/src/test/java/com/crawljax/core/configuration/AddingMultipleURLsTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/AddingMultipleURLsTest.java
@@ -1,0 +1,26 @@
+package com.crawljax.core.configuration;
+
+import java.net.MalformedURLException;
+
+import org.junit.Test;
+
+import com.crawljax.core.CrawljaxController;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+
+public class AddingMultipleURLsTest {
+	
+	@Test
+	public void testMultipleURLs() throws MalformedURLException {
+		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(AddingMultipleURLsTest.class.getResource("/site/simple.html"));
+		builder.alsoCrawl(new java.net.URL("http://google.com"));
+		CrawljaxController crawljax = new CrawljaxController(builder.build());
+	}
+	
+	@Test
+	public void testMultipleStringURLs() {
+		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(AddingMultipleURLsTest.class.getResource("/site/simple.html"));
+		builder.alsoCrawl("http://google.com");
+		CrawljaxController crawljax = new CrawljaxController(builder.build());
+	}
+	
+}

--- a/examples/src/main/java/com/crawljax/examples/CrawljaxAdvancedExampleSettings.java
+++ b/examples/src/main/java/com/crawljax/examples/CrawljaxAdvancedExampleSettings.java
@@ -19,7 +19,7 @@ public final class CrawljaxAdvancedExampleSettings {
 	private static final long WAIT_TIME_AFTER_EVENT = 200;
 	private static final long WAIT_TIME_AFTER_RELOAD = 20;
 	private static final String URL = "http://spci.st.ewi.tudelft.nl/demo/crawljax/";
-	private static final String outputDir = "output";
+	private static final String outputDir = "output2";
 
 	/**
 	 * entry point

--- a/examples/src/main/java/com/crawljax/examples/SimpleExample.java
+++ b/examples/src/main/java/com/crawljax/examples/SimpleExample.java
@@ -1,0 +1,52 @@
+package com.crawljax.examples;
+
+import org.apache.commons.configuration.ConfigurationException;
+
+import com.crawljax.core.CrawljaxController;
+import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+import com.crawljax.core.configuration.InputSpecification;
+
+
+/**
+ * L2A2's group simple example
+ */
+public final class SimpleExample{
+	
+	private static final String URL = "http://www.google.com";
+	private static final int MAX_DEPTH = 2;
+	private static final int MAX_NUMBER_STATES = 5;
+	
+	/**
+	 * Entry point
+	 */
+	public static void main(String[] args) throws ConfigurationException {
+		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(URL);
+		builder.crawlRules().insertRandomDataInInputForms(false);
+		builder.alsoCrawl("http://www.bing.com");
+		builder.alsoCrawl("http://www.yahoo.com");
+		
+		builder.crawlRules().click("a");
+		builder.crawlRules().click("button");
+		
+		// except these
+		builder.crawlRules().dontClick("a").underXPath("//DIV[@id='guser']");
+		builder.crawlRules().dontClick("a").withText("Language Tools");
+		
+		// limit the crawling scope
+		builder.setMaximumDepth(MAX_DEPTH);
+		builder.setMaximumStates(MAX_NUMBER_STATES);
+		
+		builder.crawlRules().setInputSpec(getInputSpecification());
+		
+		CrawljaxController crawljax = new CrawljaxController(builder.build());
+		crawljax.run();
+		
+	}
+	
+	private static InputSpecification getInputSpecification(){
+		InputSpecification input = new InputSpecification();
+		input.field("gbqfq").setValue("Crawljax");
+		return input;
+	}
+}


### PR DESCRIPTION
EECE310 L2A2 Group, implementing Issue #93

Crawljax is now able to crawl a path specified by using alsoCrawl() function in CrawljaxConfigurationBuilder. 

Short description regarding the implementation of this feature:
Instead of having one URL to store the seed URL, we replace the member variable with an ArrayList of URLs. By calling alsoCrawl(), new url specified by user will be added to this ArrayList.
WorkQueue is modified not to be final anymore, since it needs to crawl another URL once it is done crawling the seedURL.

Should there be any questions / concerns, please let us know.
