### PR TITLE
ISSUE #102 & ISSUE #75

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawlQueue.java
+++ b/core/src/main/java/com/crawljax/core/CrawlQueue.java
@@ -14,15 +14,11 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Original: This class implements a BlockingQueue with Runnable as its Generic type and extends Stack with
- * also Runnable as generic type. This class is used in the ThreadPoolExecutor and its used to store
- * separate threads in a Queue like fashion (FILO). </br>
- * 
- * <br> Major Overhaul: This class is now implements a BlockingQueue with a LinkedList as its data abstraction rep
- * instead of extending Stack. This is done to make it easy to change implementation between FIFO and FILO.
- * Since there's no random access involved, speed is the same as using Stack. This class is used in the ThreadPoolExecutor 
- * and processes elements in FILO (first-in-last-out). This is now also thread-safe. 
- * Lastly, this class can be either bounded or unbounded.
+ * This class implements a BlockingQueue with a LinkedList as its data abstraction rep
+ * instead of extending Stack, making it easy to change implementation between FIFO and FILO.
+ * Since there's no random access involved, speed is the same as using Stack. This class is used 
+ * in the ThreadPoolExecutor and processes elements in FILO (first-in-last-out). This is now also thread-safe. 
+ * Lastly, this class can be either bounded or unbounded(default).
  * 
  * @author Stefan Lenselink <S.R.Lenselink@student.tudelft.nl> (original implementation)</br>
  * @author Jae-Hwan Jung <jaehwan.jeff.jung@gmail.com> (Major Overhaul on March 23, 2013)

--- a/core/src/main/java/com/crawljax/core/CrawlerExecutor.java
+++ b/core/src/main/java/com/crawljax/core/CrawlerExecutor.java
@@ -23,6 +23,7 @@ import com.google.common.base.Strings;
  * Crawlers will be stored in a workQueue until a Thread will become available.
  */
 public class CrawlerExecutor extends ThreadPoolExecutor {
+	
 	private static final Logger LOGGER = LoggerFactory.getLogger(CrawlerExecutor.class);
 	/**
 	 * Counter for the number of Crawlers that in total have run. Every time a new Crawler beginning

--- a/core/src/test/java/com/crawljax/core/CrawlQueueTest.java
+++ b/core/src/test/java/com/crawljax/core/CrawlQueueTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 /**
  * Tests for CrawlQueue.java
  * @author Jae-Hwan Jung
- *
+ * @since 2013, April 
  */
 public class CrawlQueueTest {
 	

--- a/core/src/test/java/com/crawljax/core/CrawlerExecutorTest.java
+++ b/core/src/test/java/com/crawljax/core/CrawlerExecutorTest.java
@@ -10,12 +10,9 @@ import com.crawljax.browser.EmbeddedBrowser.BrowserType;
 import com.crawljax.core.configuration.BrowserConfiguration;
 
 /**
- * Original: Test the CrawlerExecutor ThreadPoolExecutor. Basically it test only the correct naming.</br></br>
+ * Original: Test the CrawlerExecutor ThreadPoolExecutor. Basically it test only the correct naming.
  * 
- * Major Overhaul on March 24, 2013 by Jae-Hwan Jung <jaehwan.jeff.jung@gmail.com>: </br>
- * Testing for correct naming does not work properly as scheduling of threads is done by the host OS.
- * As a result, the order of statements may not be the same as the order of actual execution due to the loads
- * of cores at time. 
+ * @author Jae-Hwan  Jung <jaehwan.jeff.jung@gmail.com> since 2013, March 23.
  */
 public class CrawlerExecutorTest {
 


### PR DESCRIPTION
Team L2C3 - EECE 310 

Re-opening the pull request: removed unnecessary Javadoc comments and used the formmater as requested. Below is the original pull request message.

 Work done for ISSUE #102. The issue is not resolved because the problem could not be recreated whiling running example code on 8 different websites for more than 2 times per website.
 Summary of Work:
1. Major overhaul on CrawlQueue.java. Instead of extending Stack, it now just uses a list to manually control elements. Implemented all methods for the BlockingQueue interface in Thread-safe manner.
2. Created a JUNIT test, CrawlQueueTest.java for CrawlQueue.java. Tests all the methods. Non-trivial methods are tested using multiple threads to check for thread-safeness. 
3. Modified the constructor of CrawlerExecutor,java. Originally it was unbounded but now is bounded with RejectedExecutionHandler set as CallerRunsPolicy which makes the main thread to run the task when the queue is full (instead of throwing an exception as in the original setting). Unbounded queue = source of out of memory error. Increased the default number of threads.
4. Modified CrawlerExecutorTest.java. Added more threads to test CrawlerExecutor.java and added delays. I just pulled from the original repo and it seems that somebody has already added Thread.sleep(1). Not sure this is done after I originally submitted a pull request (which I closed promptly to work more on those files and resubmit. More explanation provided below:

While working on the issue #102, found the reason for issue #75. The reason that CrawlerExecutorTest.java fails sometimes without any apparent reason is that the OS scheduler may cause the order of execution differ from the order of statements in the code. Slight delay between ThreadPoolExecutor.execute() is needed for this test to function correctly. Depending on how the OS assigns JAVA threads to cores (or OS threads) and the load of the cores at the moment, the speed of execution of the methods could differ from the actual order of calling them. As a result, sometimes this test fails when executor.execute(t2) is actually executed before executor.execute(t1). There are only two ways to fix this. First is to put a small delay (for example, Thread.sleep(SLEEPTIME)) between method callings. Or assign only one core to JAVA SE process on Windows Task Manager (or equivalent features of other OS).

Maven integration test has been passed.
