### PR TITLE
Allow crawljax to visit external urls specified by alsoCrawl(String url) - Issue #93

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
@@ -32,7 +34,7 @@ public final class CrawljaxConfiguration {
 			config = new CrawljaxConfiguration();
 			config.url = url;
 		}
-
+		
 		/**
 		 * @param states
 		 *            The maximum number of states the Crawler should crawl. The default is
@@ -88,6 +90,32 @@ public final class CrawljaxConfiguration {
 			config.maximumDepth = 0;
 			return this;
 		}
+		
+		/**
+		 * Allow Crawljax to crawl the specified external URL
+		 * @param url
+		 * 			The external URL
+		 */
+		public CrawljaxConfigurationBuilder alsoCrawlUrl(URL url) {
+			Preconditions.checkNotNull(url, "URL was null");
+			config.crawlUrls.add(url);
+			return this;
+		}
+		
+		/**
+		 * Allow Crawljax to crawl the specified external URL
+		 * @param url
+		 * 			The external URL
+		 */
+		public CrawljaxConfigurationBuilder alsoCrawlUrl(String url) {
+			try {
+				config.crawlUrls.add(new URL(url));
+			} catch (MalformedURLException e) {
+				throw new CrawljaxException("Could not read that URL", e);
+			}
+			return this;
+		}
+
 
 		/**
 		 * Add plugins to Crawljax. Note that without plugins, Crawljax won't give any ouput. For
@@ -165,6 +193,7 @@ public final class CrawljaxConfiguration {
 	}
 
 	private URL url;
+	private List<URL> crawlUrls = new ArrayList<URL>();
 
 	private BrowserConfiguration browserConfig = new BrowserConfiguration(BrowserType.firefox);
 	private Plugins plugins;
@@ -209,6 +238,10 @@ public final class CrawljaxConfiguration {
 
 	public int getMaximumDepth() {
 		return maximumDepth;
+	}
+	
+	public List<URL> getCrawlUrls() {
+		return crawlUrls;
 	}
 
 	@Override

--- a/examples/src/main/java/com/crawljax/examples/CrawljaxSimpleExampleSettings.java
+++ b/examples/src/main/java/com/crawljax/examples/CrawljaxSimpleExampleSettings.java
@@ -23,6 +23,13 @@ public final class CrawljaxSimpleExampleSettings {
 		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(URL);
 		builder.crawlRules().insertRandomDataInInputForms(false);
 
+		// Allow these external URLs to be crawled by Crawljax
+		builder.alsoCrawlUrl("http://play.google.com/");
+		builder.alsoCrawlUrl("http://mail.google.com/");
+		builder.alsoCrawlUrl("http://news.google.ca/");
+		builder.alsoCrawlUrl("http://maps.google.ca/");
+		builder.alsoCrawlUrl("http://www.youtube.com");
+		
 		builder.crawlRules().click("a");
 		builder.crawlRules().click("button");
 


### PR DESCRIPTION
Our team, Lab B1, the original team inquiring about issue #93, upon observing a rejected fail request on the same issue, has renewed our code.

How we understand is that currently Crawljax only visits links within the domain of the seed url. 

This update adds a new method, alsoCrawl(String url), within CrawljaxConfigurationBuilder
that gives Crawljax the ability to visit specified external urls.

For example, specifying builder.alsoCrawl("news.google.com"), will allow Crawljax to click any link to new.google.com.
