### PR TITLE
Reduced useless warnings in crawl overview output

### DIFF
--- a/core/src/main/java/com/crawljax/core/plugin/PreCrawlingPlugin.java
+++ b/core/src/main/java/com/crawljax/core/plugin/PreCrawlingPlugin.java
@@ -18,5 +18,5 @@ public interface PreCrawlingPlugin extends Plugin {
 	 * @param config
 	 *            The {@link CrawljaxConfiguration} for the coming crawl.
 	 */
-	void preCrawling(CrawljaxConfiguration config);
+	void preCrawling(CrawljaxConfiguration config) throws RuntimeException;
 }

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
@@ -49,6 +49,7 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 	private final OutputBuilder outputBuilder;
 	private final ConcurrentMap<String, StateVertex> visitedStates;
 	private final OutPutModelCache outModelCache;
+	private boolean warnedForElementsInIframe = false;
 
 	private OutPutModel result;
 
@@ -121,7 +122,7 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 	        CandidateElement element) {
 		try {
 			if (!Strings.isNullOrEmpty(element.getRelatedFrame())) {
-				LOG.warn("Element is in an iFrame. We cannot display it in the Crawl overview");
+				warnUserForInvisibleElements();
 				return null;
 			} else {
 				return browser.getWebElement(element.getIdentification());
@@ -131,6 +132,13 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 			return null;
 		}
 	}
+
+	private void warnUserForInvisibleElements() {
+	    if (!warnedForElementsInIframe) {
+	    	LOG.warn("Some elemnts are in an iFrame. We cannot display it in the Crawl overview");
+	    	warnedForElementsInIframe = true;
+	    }
+    }
 
 	private CandidateElementPosition findElement(WebElement webElement,
 	        CandidateElement element) {


### PR DESCRIPTION
Prevents the log output from looking like this

```
03:03:21.537 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
03:03:21.537 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
03:05:18.980 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
03:05:18.980 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
03:05:44.368 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
03:05:44.368 [pool-8-thread-3] WARN  - Element is in an iFrame. We cannot display it in the Crawl overview
```
