### PR TITLE
State vertexes can now show their candidate elements

### DIFF
--- a/core/src/main/java/com/crawljax/core/CandidateElement.java
+++ b/core/src/main/java/com/crawljax/core/CandidateElement.java
@@ -6,6 +6,7 @@ import org.w3c.dom.Element;
 
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.condition.eventablecondition.EventableCondition;
+import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.Identification;
 import com.crawljax.forms.FormInput;
 import com.crawljax.util.DomUtils;
@@ -14,8 +15,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Candidate element for crawling. It is possible to link this eventable to form inputs, so that
- * crawljax knows which values to set for this elements before it is clicked.
+ * Candidate element for crawling. It is possible to link this {@link Eventable} to form inputs, so
+ * that Crawljax knows which values to set for this elements before it is clicked.
  */
 public class CandidateElement {
 
@@ -24,8 +25,9 @@ public class CandidateElement {
 	private final Element element;
 
 	private final ImmutableList<FormInput> formInputs;
-	private EventableCondition eventableCondition;
 	private final String relatedFrame;
+
+	private EventableCondition eventableCondition;
 
 	/**
 	 * Constructor for a element a identification and a relatedFrame.
@@ -160,5 +162,4 @@ public class CandidateElement {
 		        .add("relatedFrame", relatedFrame)
 		        .toString();
 	}
-
 }

--- a/core/src/main/java/com/crawljax/core/CandidateElementExtractor.java
+++ b/core/src/main/java/com/crawljax/core/CandidateElementExtractor.java
@@ -136,7 +136,7 @@ public class CandidateElementExtractor {
 		if (randomizeElementsOrder) {
 			Collections.shuffle(results);
 		}
-
+		currentState.setElementsFound(results);
 		LOG.debug("Found {} new candidate elements to analyze!", results.size());
 		return ImmutableList.copyOf(results);
 	}

--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -385,9 +385,8 @@ public class Crawler {
 		StateVertex currentState = stateMachine.getCurrentState();
 		LOG.debug("Parsing DOM of state {} for candidate elements", currentState.getName());
 		ImmutableList<CandidateElement> extract = candidateExtractor.extract(currentState);
-
+		
 		plugins.runPreStateCrawlingPlugins(context, extract, currentState);
-
 		candidateActionCache.addActions(extract, currentState);
 	}
 

--- a/core/src/main/java/com/crawljax/core/state/StateVertex.java
+++ b/core/src/main/java/com/crawljax/core/state/StateVertex.java
@@ -2,9 +2,11 @@ package com.crawljax.core.state;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.LinkedList;
 
 import org.w3c.dom.Document;
 
+import com.crawljax.core.CandidateElement;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -53,6 +55,18 @@ public interface StateVertex extends Serializable {
 	 */
 	Document getDocument() throws IOException;
 
-	ImmutableList<Eventable> getUsedEventables();
+	/**
+	 * @param elements
+	 *            Set the candidate elements for this state vertex that might be fired.
+	 */
+	void setElementsFound(LinkedList<CandidateElement> elements);
+
+	/**
+	 * @return A list of {@link CandidateElement} that might have been fired during the crawl. If an
+	 *         event was fired it is registered as an {@link Eventable} an can be retrieved from
+	 *         {@link StateFlowGraph#getAllEdges()}. If the candidates were not set because of an
+	 *         error it returns <code>null</code>.
+	 */
+	ImmutableList<CandidateElement> getCandidateElements();
 
 }

--- a/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
+++ b/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
@@ -2,9 +2,11 @@ package com.crawljax.core.state;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.LinkedList;
 
 import org.w3c.dom.Document;
 
+import com.crawljax.core.CandidateElement;
 import com.crawljax.util.DomUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
@@ -26,6 +28,8 @@ class StateVertexImpl implements StateVertex {
 	private final String strippedDom;
 	private final String url;
 	private String name;
+
+	private ImmutableList<CandidateElement> candidateElements;
 
 	/**
 	 * Creates a current state without an url and the stripped dom equals the dom.
@@ -122,7 +126,14 @@ class StateVertexImpl implements StateVertex {
 	}
 
 	@Override
-	public ImmutableList<Eventable> getUsedEventables() {
-		return ImmutableList.copyOf(this.foundEventables);
+	public void setElementsFound(LinkedList<CandidateElement> elements) {
+		this.candidateElements = ImmutableList.copyOf(elements);
+
 	}
+
+	@Override
+	public ImmutableList<CandidateElement> getCandidateElements() {
+		return candidateElements;
+	}
+
 }

--- a/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
@@ -35,7 +35,7 @@ public class StatesContainElementsTest {
 		Set<StateVertex> allStates = crawl.getStateFlowGraph().getAllStates();
 		for (StateVertex stateVertex : allStates) {
 			if ("index".equals(stateVertex.getName())) {
-				assertThat(stateVertex.getUsedEventables(), is(not(empty())));
+				assertThat(stateVertex.getCandidateElements(), is(not(empty())));
 			}
 		}
 	}


### PR DESCRIPTION
Candidate elements are set in the state vertex once the
CandidateElementExtractor has parsed the DOM. This way, you can see
which elements were fired once the crawl is down.

These elemets are CandidateElements not Eventables because if they are
not fired, they are not an Eventable (meaning a link between vertexes).
For that reason, the method `getUsedEventables()` was removed from
StateVertex. To be able to figure out which eventables were fired and
which weren't, you can retreived the edged going out of a state.

Fixes #350
