### PR TITLE
Crawler checks if left domain by hostname.

### DIFF
--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -408,8 +408,7 @@ public class Crawler {
 	}
 
 	private boolean crawlerLeftDomain() {
-		return !browser.getCurrentUrl().toLowerCase()
-		        .contains(url.getHost().toLowerCase());
+		return !UrlUtils.isSameDomain(browser.getCurrentUrl(), url);
 	}
 
 	private long parseWaitTimeOrReturnDefault(Matcher m) {

--- a/core/src/main/java/com/crawljax/util/UrlUtils.java
+++ b/core/src/main/java/com/crawljax/util/UrlUtils.java
@@ -1,6 +1,8 @@
 package com.crawljax.util;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.regex.PatternSyntaxException;
 
@@ -91,6 +93,26 @@ public class UrlUtils {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Checks if the given URL is part of the domain, or a subdomain of the given {@link URL}.
+	 * 
+	 * @param currentUrl
+	 *            The url you want to check.
+	 * @param url
+	 *            The URL acting as the base.
+	 * @return If the URL is part of the domain.
+	 */
+	public static boolean isSameDomain(String currentUrl, URL url) {
+		try {
+			String current = URI.create(currentUrl).getHost().toLowerCase();
+			String original = url.toURI().getHost().toLowerCase();
+			return current.endsWith(original);
+		} catch (URISyntaxException e) {
+			LOG.warn("Could not parse URI {}", currentUrl);
+			return false;
+		}
 	}
 
 	private UrlUtils() {

--- a/core/src/test/java/com/crawljax/util/UrlUtilsTest.java
+++ b/core/src/test/java/com/crawljax/util/UrlUtilsTest.java
@@ -65,4 +65,23 @@ public class UrlUtilsTest {
 
 	}
 
+	@Test
+	public void testIsSameDomain() throws MalformedURLException {
+
+		// Same URL
+		assertThat(UrlUtils.isSameDomain("http://example.com",
+		        new URL("http://example.com")), is(true));
+
+		// Different URL
+		assertThat(UrlUtils.isSameDomain("http://test.com",
+		        new URL("http://example.com")), is(false));
+
+		// Same URL with subdomain
+		assertThat(UrlUtils.isSameDomain("http://test.example.com",
+		        new URL("http://example.com")), is(true));
+
+		// Same URL but with HTTPS
+		assertThat(UrlUtils.isSameDomain("https://example.com",
+		        new URL("http://example.com")), is(true));
+	}
 }


### PR DESCRIPTION
Before this was done using `String.contains(x)`. However, that does not
work when in the new URL on another domain, the original domain is
passed through as a query parameter. Because the new method compares
hostnames, this cannot happen anymore.

Fixes #339
