### PR TITLE
You can now specify a custom StateVertex factory.

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -13,6 +13,7 @@ import com.crawljax.core.Crawler;
 import com.crawljax.core.CrawljaxException;
 import com.crawljax.core.configuration.CrawlRules.CrawlRulesBuilder;
 import com.crawljax.core.plugin.Plugin;
+import com.crawljax.core.state.StateVertexFactory;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -153,6 +154,22 @@ public class CrawljaxConfiguration {
 		}
 
 		/**
+		 * Set a custom {@link com.crawljax.core.state.StateVertexFactory} to be able to use your own
+		 * {@link com.crawljax.core.state.StateVertex} objects. This is useful when you want to have a custom
+		 * comparator
+		 * in the stateflowgraph which relies on the {@link Object#hashCode()} or {@link Object#equals(Object)} of the
+		 * {@link com.crawljax.core.state.StateVertex}.
+		 *
+		 * @param vertexFactory The factory you want to use.
+		 * @return The builder for method chaining.
+		 */
+		public CrawljaxConfigurationBuilder setStateVertexFactory(StateVertexFactory vertexFactory) {
+			Preconditions.checkNotNull(vertexFactory);
+			config.stateVertexFactory = vertexFactory;
+			return this;
+		}
+
+		/**
 		 * Set the output folder for any {@link Plugin} you might configure. Crawljax itself doesn't
 		 * need an output folder but many plug-ins do.
 		 *
@@ -217,6 +234,8 @@ public class CrawljaxConfiguration {
 	private int maximumDepth = 2;
 	private File output = new File("out");
 
+	private StateVertexFactory stateVertexFactory;
+
 	private CrawljaxConfiguration() {
 	}
 
@@ -254,6 +273,11 @@ public class CrawljaxConfiguration {
 
 	public File getOutputDir() {
 		return output;
+	}
+
+
+	public StateVertexFactory getStateVertexFactory() {
+		return stateVertexFactory;
 	}
 
 	@Override

--- a/core/src/main/java/com/crawljax/core/plugin/DomChangeNotifierPlugin.java
+++ b/core/src/main/java/com/crawljax/core/plugin/DomChangeNotifierPlugin.java
@@ -9,6 +9,16 @@ package com.crawljax.core.plugin;
 import com.crawljax.core.CrawlerContext;
 import com.crawljax.core.state.Eventable;
 
+/**
+ * This plugins lets you override the default state comparison that Crawljax uses.
+ *
+ * @deprecated Allthough new states are selected based on this plugin, the actual state comparison used by the
+ * backing StateFlowGraph is uses the {@link Object#hashCode()} and {@link Object#equals(Object)} function of the
+ * {@link com.crawljax.core.state.StateVertex}. To implement correct behaviour, do note use this class but specify a
+ * custom {@link com.crawljax.core.state.StateVertexFactory} in the
+ * {@link com.crawljax.core.configuration.CrawljaxConfiguration}. This method will be removed in Crawljax 4.x
+ */
+@Deprecated
 public interface DomChangeNotifierPlugin extends Plugin {
 
 	/**
@@ -16,15 +26,14 @@ public interface DomChangeNotifierPlugin extends Plugin {
 	 * <p>
 	 * This method can be called from multiple threads with different {@link CrawlerContext}
 	 * </p>
-	 * 
-	 * @param context
-	 *            The Crawler context.
-	 * @param domBefore
-	 *            the state before the event.
-	 * @param domAfter
-	 *            the state after the event.
+	 *
+	 * @param context   The Crawler context.
+	 * @param domBefore the state before the event.
+	 * @param domAfter  the state after the event.
 	 * @return true if the state is changed according to the compare method of the oracle.
+	 * @deprecated See class documentation. This method will be removed in Crawljax 4.x
 	 */
+	@Deprecated
 	boolean isDomChanged(CrawlerContext context, String domBefore, Eventable e, String domAfter);
 
 }

--- a/core/src/main/java/com/crawljax/core/state/DefaultStateVertexFactory.java
+++ b/core/src/main/java/com/crawljax/core/state/DefaultStateVertexFactory.java
@@ -1,0 +1,13 @@
+package com.crawljax.core.state;
+
+/**
+ * The default factory that creates State vertexes with a {@link Object#hashCode()} and {@link Object#equals(Object)}
+ * function based on the Stripped dom.
+ */
+public class DefaultStateVertexFactory extends StateVertexFactory {
+
+	@Override
+	public StateVertex newStateVertex(int id, String url, String name, String dom, String strippedDom) {
+		return new StateVertexImpl(id, url, name, dom, strippedDom);
+	}
+}

--- a/core/src/main/java/com/crawljax/core/state/StateMachine.java
+++ b/core/src/main/java/com/crawljax/core/state/StateMachine.java
@@ -18,13 +18,6 @@ public class StateMachine {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(StateMachine.class.getName());
 
-	/**
-	 * @return The index {@link StateVertex}.
-	 */
-	public static StateVertex createIndex(String url, String dom, String strippedDom) {
-		return new StateVertexImpl(StateVertex.INDEX_ID, url, "index", dom, strippedDom);
-	}
-
 	private final InMemoryStateFlowGraph stateFlowGraph;
 
 	private final StateVertex initialState;

--- a/core/src/main/java/com/crawljax/core/state/StateVertexFactory.java
+++ b/core/src/main/java/com/crawljax/core/state/StateVertexFactory.java
@@ -1,0 +1,27 @@
+package com.crawljax.core.state;
+
+/**
+ * A factory that creates a {@link com.crawljax.core.state.StateVertex}. This factory can be implemented
+ * if you want to use custom states that use a different {@link Object#hashCode()} or {@link Object#equals(Object)}
+ * method.
+ */
+public abstract class StateVertexFactory {
+
+	/**
+	 * Defines a State.
+	 *
+	 * @param url         the current url of the state
+	 * @param name        the name of the state
+	 * @param dom         the current DOM tree of the browser
+	 * @param strippedDom the stripped dom by the OracleComparators
+	 */
+	public abstract StateVertex newStateVertex(int id, String url, String name, String dom, String strippedDom);
+
+
+	/**
+	 * @return The index {@link StateVertex}.
+	 */
+	public StateVertex createIndex(String url, String dom, String strippedDom) {
+		return newStateVertex(StateVertex.INDEX_ID, url, "index", dom, strippedDom);
+	}
+}

--- a/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
+++ b/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
@@ -1,17 +1,14 @@
 package com.crawljax.core.state;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.LinkedList;
-
-import org.w3c.dom.Document;
 
 import com.crawljax.core.CandidateElement;
 import com.crawljax.util.DomUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Queues;
+import org.w3c.dom.Document;
 
 /**
  * The state vertex class which represents a state in the browser. When iterating over the possible
@@ -22,7 +19,6 @@ class StateVertexImpl implements StateVertex {
 
 	private static final long serialVersionUID = 123400017983488L;
 
-	private final Collection<Eventable> foundEventables;
 	private final int id;
 	private final String dom;
 	private final String strippedDom;
@@ -62,7 +58,6 @@ class StateVertexImpl implements StateVertex {
 		this.name = name;
 		this.dom = dom;
 		this.strippedDom = strippedDom;
-		foundEventables = Queues.newConcurrentLinkedQueue();
 	}
 
 	@Override
@@ -115,14 +110,6 @@ class StateVertexImpl implements StateVertex {
 	@Override
 	public Document getDocument() throws IOException {
 		return DomUtils.asDocument(this.dom);
-	}
-
-	/**
-	 * @param eventable
-	 *            The eventable that was clicked in this state.
-	 */
-	public void registerEventable(Eventable eventable) {
-		foundEventables.add(eventable);
 	}
 
 	@Override

--- a/core/src/main/java/com/crawljax/di/CoreModule.java
+++ b/core/src/main/java/com/crawljax/di/CoreModule.java
@@ -14,8 +14,10 @@ import com.crawljax.core.CrawlSession;
 import com.crawljax.core.ExitNotifier;
 import com.crawljax.core.ExtractorManager;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.state.DefaultStateVertexFactory;
 import com.crawljax.core.state.InMemoryStateFlowGraph;
 import com.crawljax.core.state.StateFlowGraph;
+import com.crawljax.core.state.StateVertexFactory;
 import com.crawljax.forms.FormHandler;
 import com.crawljax.metrics.MetricsModule;
 import com.google.inject.AbstractModule;
@@ -54,6 +56,12 @@ public class CoreModule extends AbstractModule {
 
 		install(new FactoryModuleBuilder().build(FormHandlerFactory.class));
 		install(new FactoryModuleBuilder().build(CandidateElementExtractorFactory.class));
+
+		if (configuration.getStateVertexFactory() == null) {
+			bind(StateVertexFactory.class).to(DefaultStateVertexFactory.class);
+		} else {
+			bind(StateVertexFactory.class).toInstance(configuration.getStateVertexFactory());
+		}
 
 	}
 

--- a/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
+++ b/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
@@ -11,6 +11,20 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
+import com.crawljax.browser.EmbeddedBrowser;
+import com.crawljax.browser.WebDriverBrowserBuilder;
+import com.crawljax.condition.ConditionTypeChecker;
+import com.crawljax.condition.crawlcondition.CrawlCondition;
+import com.crawljax.condition.eventablecondition.EventableConditionChecker;
+import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+import com.crawljax.core.plugin.Plugins;
+import com.crawljax.core.state.DefaultStateVertexFactory;
+import com.crawljax.core.state.StateVertex;
+import com.crawljax.forms.FormHandler;
+import com.crawljax.test.BrowserTest;
+import com.crawljax.test.RunWithWebServer;
+import com.google.common.io.Resources;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -22,28 +36,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.crawljax.browser.EmbeddedBrowser;
-import com.crawljax.browser.WebDriverBrowserBuilder;
-import com.crawljax.condition.ConditionTypeChecker;
-import com.crawljax.condition.crawlcondition.CrawlCondition;
-import com.crawljax.condition.eventablecondition.EventableConditionChecker;
-import com.crawljax.core.configuration.CrawljaxConfiguration;
-import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
-import com.crawljax.core.plugin.Plugins;
-import com.crawljax.core.state.StateMachine;
-import com.crawljax.core.state.StateVertex;
-import com.crawljax.forms.FormHandler;
-import com.crawljax.test.BrowserTest;
-import com.crawljax.test.RunWithWebServer;
-import com.google.common.io.Resources;
-
 @Category(BrowserTest.class)
 @RunWith(MockitoJUnitRunner.class)
 public class CandidateElementExtractorTest {
 
 	private static final Logger LOG = LoggerFactory
 	        .getLogger(CandidateElementExtractorTest.class);
-	private static final StateVertex DUMMY_STATE = StateMachine.createIndex("http://localhost",
+	private static final StateVertex DUMMY_STATE = new DefaultStateVertexFactory().createIndex("http://localhost",
 	        "", "");
 
 	@Mock

--- a/core/src/test/java/com/crawljax/core/CrawlerTest.java
+++ b/core/src/test/java/com/crawljax/core/CrawlerTest.java
@@ -16,6 +16,7 @@ import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.condition.browserwaiter.WaitConditionChecker;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.plugin.Plugins;
+import com.crawljax.core.state.DefaultStateVertexFactory;
 import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.Identification;
 import com.crawljax.core.state.Identification.How;
@@ -125,7 +126,7 @@ public class CrawlerTest {
 		        new Crawler(context, config,
 		                stateComparator,
 		                candidateActionCache, formHandlerFactory, waitConditionChecker,
-		                elementExtractor, graphProvider, plugins);
+		                elementExtractor, graphProvider, plugins, new DefaultStateVertexFactory());
 
 		setupStateFlowGraph();
 	}

--- a/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
@@ -17,15 +17,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.crawljax.condition.NotRegexCondition;
 import com.crawljax.condition.NotXPathCondition;
 import com.crawljax.condition.RegexCondition;
@@ -53,6 +44,14 @@ import com.crawljax.oraclecomparator.OracleComparator;
 import com.crawljax.oraclecomparator.comparators.DateComparator;
 import com.crawljax.oraclecomparator.comparators.StyleComparator;
 import com.crawljax.test.RunWithWebServer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the base abstract class for all different kind of largeTests. Sub classes tests specific
@@ -82,7 +81,7 @@ public abstract class LargeTestBase {
 
 	private static final String TITLE_RESULT_RANDOM_INPUT = "RESULT_RANDOM_INPUT";
 	private static final String REGEX_RESULT_RANDOM_INPUT = "[a-zA-Z]{8};" + "[a-zA-Z]{8};"
-	        + "(true|false);" + "(true|false);" + "OPTION[1234];" + "[a-zA-Z]{8}";
+	  + "(true|false);" + "(true|false);" + "OPTION[1234];" + "[a-zA-Z]{8}";
 
 	// manual values
 	private static final String TITLE_MANUAL_INPUT_RESULT = "RESULT_MANUAL_INPUT";
@@ -104,7 +103,7 @@ public abstract class LargeTestBase {
 
 	private static final String TITLE_MULTIPLE_INPUT_RESULT = "RESULT_MULTIPLE_INPUT";
 	private static final String[] MULTIPLE_INPUT_RESULTS = { "first;foo;true;false;OPTION1;same",
-	        "second;bar;false;true;OPTION2;same", ";foo;true;false;OPTION1;same" };
+	  "second;bar;false;true;OPTION2;same", ";foo;true;false;OPTION1;same" };
 
 	@ClassRule
 	public static final RunWithWebServer WEB_SERVER = new RunWithWebServer("/site");
@@ -120,7 +119,8 @@ public abstract class LargeTestBase {
 			crawljax = new CrawljaxRunner(getCrawljaxConfiguration());
 			session = crawljax.call();
 			HAS_FINISHED.set(true);
-		} else {
+		}
+		else {
 			while (!HAS_FINISHED.get()) {
 				LOG.debug("Waiting for crawl to finish...");
 				Thread.sleep(500);
@@ -134,10 +134,10 @@ public abstract class LargeTestBase {
 	protected CrawljaxConfiguration getCrawljaxConfiguration() {
 
 		CrawljaxConfigurationBuilder builder =
-		        CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl());
+		  CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl());
 		builder.crawlRules().waitAfterEvent(getTimeOutAfterEvent(), TimeUnit.MILLISECONDS);
 		builder.crawlRules()
-		        .waitAfterReloadUrl(getTimeOutAfterReloadUrl(), TimeUnit.MILLISECONDS);
+			   .waitAfterReloadUrl(getTimeOutAfterReloadUrl(), TimeUnit.MILLISECONDS);
 		builder.setMaximumDepth(3);
 		builder.crawlRules().clickOnce(true);
 
@@ -178,24 +178,24 @@ public abstract class LargeTestBase {
 
 	private static void addWaitConditions(CrawljaxConfigurationBuilder crawler) {
 		crawler.crawlRules().addWaitCondition(
-		        new WaitCondition("testWaitCondition.html", 2000, new ExpectedVisibleCondition(
-		                new Identification(How.id, "SLOW_WIDGET"))));
+		  new WaitCondition("testWaitCondition.html", 2000, new ExpectedVisibleCondition(
+			new Identification(How.id, "SLOW_WIDGET"))));
 	}
 
 	private static void addInvariants(CrawljaxConfigurationBuilder builder) {
 		// should always fail on test invariant page
 		NotXPathCondition neverDivWithInvariantViolationId =
-		        new NotXPathCondition("//DIV[@id='INVARIANT_VIOLATION']");
+		  new NotXPathCondition("//DIV[@id='INVARIANT_VIOLATION']");
 		builder.crawlRules().addInvariant(VIOLATED_INVARIANT_DESCRIPTION,
-		        neverDivWithInvariantViolationId);
+		  neverDivWithInvariantViolationId);
 
 		// should never fail
 		RegexCondition onInvariantsPagePreCondition = new RegexCondition(INVARIANT_TEXT);
 		XPathCondition expectElement =
-		        new XPathCondition("//DIV[@id='SHOULD_ALWAYS_BE_ON_THIS_PAGE']");
+		  new XPathCondition("//DIV[@id='SHOULD_ALWAYS_BE_ON_THIS_PAGE']");
 		builder.crawlRules().addInvariant(
-		        new Invariant("testInvariantWithPrecondiions", expectElement,
-		                onInvariantsPagePreCondition));
+		  new Invariant("testInvariantWithPrecondiions", expectElement,
+			onInvariantsPagePreCondition));
 	}
 
 	private static void addCrawlElements(CrawljaxConfigurationBuilder builder) {
@@ -205,7 +205,7 @@ public abstract class LargeTestBase {
 		rules.click("div").underXPath("//SPAN[@id='" + CLICK_UNDER_XPATH_ID + "']");
 		rules.click("button").when(new NotRegexCondition("DONT_CLICK_BUTTONS_ON_THIS_PAGE"));
 		rules.click("div").withAttribute(ATTRIBUTE, "condition")
-		        .when(new RegexCondition("REGEX_CONDITION_TRUE"));
+			 .when(new RegexCondition("REGEX_CONDITION_TRUE"));
 
 		rules.dontClick("a").withText(DONT_CLICK_TEXT);
 		rules.dontClick("a").withAttribute(ATTRIBUTE, DONT_CLICK_TEXT);
@@ -214,22 +214,21 @@ public abstract class LargeTestBase {
 
 	private static void addOracleComparators(CrawljaxConfigurationBuilder builder) {
 		builder.crawlRules().addOracleComparator(
-		        new OracleComparator("style", new StyleComparator()));
+		  new OracleComparator("style", new StyleComparator()));
 
 		builder.crawlRules().addOracleComparator(
-		        new OracleComparator("date", new DateComparator()));
+		  new OracleComparator("date", new DateComparator()));
 	}
 
 	private static void addCrawlConditions(CrawljaxConfigurationBuilder builder) {
 		builder.crawlRules().addCrawlCondition("DONT_CRAWL_ME",
-		        new NotRegexCondition("DONT_CRAWL_ME"));
+		  new NotRegexCondition("DONT_CRAWL_ME"));
 	}
 
 	/**
 	 * Add the plugins to the given crawljaxConfiguration.
-	 * 
-	 * @param crawljaxConfiguration
-	 *            the configuration to add the plugins to.
+	 *
+	 * @param crawljaxConfiguration the configuration to add the plugins to.
 	 */
 	protected static void addPlugins(CrawljaxConfigurationBuilder crawljaxConfiguration) {
 		crawljaxConfiguration.addPlugin(new PostCrawlStateGraphChecker());
@@ -276,7 +275,7 @@ public abstract class LargeTestBase {
 		for (StateVertex state : getStateFlowGraph().getAllStates()) {
 			if (state.getDom().contains(TITLE_MANUAL_INPUT_RESULT)) {
 				assertTrue("Result contains the correct data",
-				        state.getDom().contains(MANUAL_INPUT_RESULT));
+				  state.getDom().contains(MANUAL_INPUT_RESULT));
 				return;
 			}
 		}
@@ -312,13 +311,14 @@ public abstract class LargeTestBase {
 
 			// elements with DONT_CLICK_TEXT should never be clicked
 			assertTrue("No illegal element is clicked: " + eventable, !eventable.getElement()
-			        .getText().startsWith(DONT_CLICK_TEXT));
+																				.getText().startsWith
+				(DONT_CLICK_TEXT));
 			if (eventable.getElement().getText().startsWith(CLICK_TEXT)) {
 				clickMeFound++;
 			}
 		}
 		assertTrue(CLICKED_CLICK_ME_ELEMENTS + " CLICK_TEXT elements are clicked ",
-		        clickMeFound == CLICKED_CLICK_ME_ELEMENTS);
+		  clickMeFound == CLICKED_CLICK_ME_ELEMENTS);
 	}
 
 	/**
@@ -327,7 +327,7 @@ public abstract class LargeTestBase {
 	@Test
 	public void testForIllegalStates() {
 		assertThat(getStateFlowGraph().getAllStates(),
-		        everyItem(not(stateWithDomSubstring(ILLEGAL_STATE))));
+		  everyItem(not(stateWithDomSubstring(ILLEGAL_STATE))));
 	}
 
 	/**
@@ -353,11 +353,13 @@ public abstract class LargeTestBase {
 	public void testInvariants() {
 		// two invariants were added, but only one should fail!
 		assertTrue(violatedInvariants.size() + " Invariants violated",
-		        violatedInvariants.size() == VIOLATED_INVARIANTS);
+		  violatedInvariants.size() == VIOLATED_INVARIANTS);
 
 		// test whether the right invariant failed
 		assertTrue(VIOLATED_INVARIANT_DESCRIPTION + " failed", violatedInvariants.get(0)
-		        .getDescription().equals(VIOLATED_INVARIANT_DESCRIPTION));
+																				 .getDescription()
+																				 .equals(
+																				   VIOLATED_INVARIANT_DESCRIPTION));
 	}
 
 	/**
@@ -367,7 +369,7 @@ public abstract class LargeTestBase {
 	@Ignore("This test is non-deterministic and will fail without cause.")
 	public void testCorrectStateOnViolatedInvariants() {
 		assertTrue("OnViolatedInvariantPlugin session object has the correct currentState",
-		        violatedInvariantStateIsCorrect);
+		  violatedInvariantStateIsCorrect);
 	}
 
 	/**
@@ -378,7 +380,7 @@ public abstract class LargeTestBase {
 		boolean foundSlowWidget = false;
 		for (StateVertex state : getStateFlowGraph().getAllStates()) {
 			if (state.getDom().contains("TEST_WAITCONDITION")
-			        && state.getDom().contains("LOADED_SLOW_WIDGET")) {
+			  && state.getDom().contains("LOADED_SLOW_WIDGET")) {
 				foundSlowWidget = true;
 			}
 		}

--- a/core/src/test/java/com/crawljax/core/state/EventableTest.java
+++ b/core/src/test/java/com/crawljax/core/state/EventableTest.java
@@ -130,7 +130,7 @@ public class EventableTest {
 
 		StateVertex s1 = new StateVertexImpl(0, "stateSource", "dom1");
 		StateVertex s2 = new StateVertexImpl(0, "stateTarget", "dom2");
-		InMemoryStateFlowGraph sfg = new InMemoryStateFlowGraph(new ExitNotifier(0));
+		InMemoryStateFlowGraph sfg = new InMemoryStateFlowGraph(new ExitNotifier(0), new DefaultStateVertexFactory());
 		sfg.putIndex(s1);
 
 		sfg.putIfAbsent(s2);

--- a/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
@@ -40,7 +40,7 @@ public class StateFlowGraphTest {
 		state3 = new StateVertexImpl(3, "STATE_THREE", "<table><div>state3</div></table>");
 		state4 = new StateVertexImpl(4, "STATE_FOUR", "<table><div>state4</div></table>");
 		state5 = new StateVertexImpl(5, "STATE_FIVE", "<table><div>state5</div></table>");
-		graph = new InMemoryStateFlowGraph(new ExitNotifier(0));
+		graph = new InMemoryStateFlowGraph(new ExitNotifier(0), new DefaultStateVertexFactory());
 		graph.putIndex(index);
 	}
 
@@ -145,7 +145,7 @@ public class StateFlowGraphTest {
 		                + "<SCRIPT src='js/jquery-1.2.3.js' type='text/javascript'></SCRIPT>"
 		                + "<body><div id='firstdiv' class='orange'>";
 
-		InMemoryStateFlowGraph g = new InMemoryStateFlowGraph(new ExitNotifier(0));
+		InMemoryStateFlowGraph g = new InMemoryStateFlowGraph(new ExitNotifier(0), new DefaultStateVertexFactory());
 		g.putIndex(new StateVertexImpl(1, "", HTML1));
 		g.putIfAbsent(new StateVertexImpl(2, "", HTML2));
 

--- a/core/src/test/java/com/crawljax/core/state/StateMachineTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateMachineTest.java
@@ -233,7 +233,7 @@ public class StateMachineTest {
 	}
 
 	private InMemoryStateFlowGraph newStateFlowGraph() {
-		InMemoryStateFlowGraph sfg = new InMemoryStateFlowGraph(new ExitNotifier(0));
+		InMemoryStateFlowGraph sfg = new InMemoryStateFlowGraph(new ExitNotifier(0), new DefaultStateVertexFactory());
 		sfg.putIndex(index);
 		return sfg;
 	}

--- a/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
@@ -1,0 +1,54 @@
+package com.crawljax.core.state;
+
+import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.crawljax.core.CrawlSession;
+import com.crawljax.core.CrawljaxRunner;
+import com.crawljax.core.ExitNotifier;
+import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.test.RunWithWebServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class StateVertexFactoryTest {
+
+	@ClassRule
+	public static final RunWithWebServer SERVER = new RunWithWebServer("/site");
+
+	/**
+	 * By creating a stat comparator that always returns true, there is only one state. This test asserts that only one
+	 * state is added to the stateflowgraph.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void whenStateVertexFactoryDefinedItIsUsedToCompareStates() throws Exception {
+		CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = SERVER.newConfigBuilder("infinite.html");
+		builder.setStateVertexFactory(new StateVertexFactory() {
+			@Override
+			public StateVertex newStateVertex(int id, String url, String name, String dom, String strippedDom) {
+				return new StateVertexImpl(id, url, name, dom, strippedDom) {
+
+					@Override
+					public int hashCode() {
+						return 1;
+					}
+
+					@Override
+					public boolean equals(Object object) {
+						return true;
+					}
+				};
+			}
+		});
+		int depth = 3;
+
+		CrawljaxRunner runner = new CrawljaxRunner(builder.setMaximumDepth(depth).build());
+		CrawlSession session = runner.call();
+
+		assertThat(session.getStateFlowGraph(), hasStates(1));
+		assertThat(runner.getReason(), is(ExitNotifier.ExitStatus.EXHAUSTED));
+	}
+}


### PR DESCRIPTION
The hashcode and equals in the StateVertex are used in the
StateFlowGraph that Crawljax uses. This means that using a custom DOM
comparator has no use, because in the back-end, the hashcode and equals
will determine the behaviour. This commit fixes that by allowing a user
to specify a custom StateVertex factory where you can create your own
StateVertexes with custom hashcode/equals methods.

Fixes #347 

@mehdimir Could you check that this has the desired behavior for you?
