### PR TITLE
When Basic auth is configured the URL isn't changed.

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -49,10 +49,8 @@ public class CrawljaxConfiguration {
 			try {
 				String encodedUsername = URLEncoder.encode(username, "UTF-8");
 				String encodedPassword = URLEncoder.encode(password, "UTF-8");
-				config.url = URI.create(config.url.getScheme()
-				  + "://" + encodedUsername
-				  + ":" + encodedPassword + "@" + config.url.getAuthority()
-				  + config.url.getPath());
+				String hostPrefix = encodedUsername + ":" + encodedPassword + "@";
+				config.url = URI.create(config.url.toString().replaceFirst("://", "://" + hostPrefix));
 			}
 			catch (UnsupportedEncodingException e) {
 				throw new CrawljaxException("Could not parse the username/password to a URL", e);

--- a/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+import org.hamcrest.core.Is;
+import org.junit.Test;
 
 public class CrawljaxConfigurationBuilderTest {
 
@@ -47,6 +47,16 @@ public class CrawljaxConfigurationBuilderTest {
 	public void ifCannotCreateOutputFolderReject() throws Exception {
 		File file = new File("/this/should/not/be/writable");
 		testBuilder().setOutputDirectory(file).build();
+	}
+
+
+	@Test
+	public void whenSpecifyingBasicAuthTheUrlShouldBePreserved() {
+		String url = "https://example.com/test/?a=b#anchor";
+		CrawljaxConfiguration conf = CrawljaxConfiguration.builderFor(url)
+				.setBasicAuth("username", "password")
+				.build();
+		assertThat(conf.getUrl().toString(), Is.is("https://username:password@example.com/test/?a=b#anchor"));
 	}
 
 }


### PR DESCRIPTION
When Basic auth was configured, it used to forget to copy the query and fragment parts of the URL. This fix copies the entire URL when adding the username and password.

Fixes #388
