### PR TITLE
fixing #408

### DIFF
--- a/web/src/main/config/logback.xml
+++ b/web/src/main/config/logback.xml
@@ -2,16 +2,15 @@
 <configuration>
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<level>WARN</level>
+		</filter>
 		<!-- encoders are assigned by default the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
 		<encoder>
 			<pattern>[%thread] %-5level %logger{46} - %msg%n</pattern>
 		</encoder>
 	</appender>
 
-
-
-	<logger name="com.crawljax.web" level="INFO" />
-	
 	<appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
     <discriminator>
       <key>crawl_record</key>
@@ -28,7 +27,7 @@
     </sift>
   </appender>
 
-	<root level="WARN">
+	<root level="INFO">
 		<appender-ref ref="STDOUT" />
 		<appender-ref ref="SIFT" />
 	</root>


### PR DESCRIPTION
Sets the root log level to `INFO` and sets a ThresholdFilter for everything below `WARN` for console logs to reduce noise. The motive is explained in #408 
