### PR TITLE
Fix for #406

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -83,6 +83,7 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 			}
 		} catch (IllegalStateException e) {
 			LOGGER.error("Crawling with {} failed: " + e.getMessage(), browserType.toString());
+			throw e;
 		}
 		plugins.runOnBrowserCreatedPlugins(browser);
 		return browser;


### PR DESCRIPTION
This fixes the issue #406 by printing the error log and re-throwing the error, therefore sending the message to the Web UI. This is done here because higher level Guice classes are not using the logback logger. Formatting changes are there because try/catch block changes indentation of a whole block.

See #407 for the earlier attempt.
