### PR TITLE
[CrawlOverview] Add option to store stripped DOM at OnNewState

### DIFF
--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
@@ -47,7 +47,7 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 	private final OutPutModelCache outModelCache;
 	private OutputBuilder outputBuilder;
 	private boolean warnedForElementsInIframe = false;
-    private boolean shouldPersistStrippedDom = false;
+	private boolean shouldPersistStrippedDom = false;
 
 	private OutPutModel result;
 
@@ -86,14 +86,14 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 		StateBuilder state = outModelCache.addStateIfAbsent(vertex);
 		visitedStates.putIfAbsent(state.getName(), vertex);
 		saveScreenshot(context.getBrowser(), state.getName(), vertex);
-        
-        if (shouldPersistStrippedDom) {
-            outputBuilder.persistDom(state.getName(), vertex.getStrippedDom());
-        } else {
-            outputBuilder
-                    .persistDom(state.getName(), context.getBrowser().getDom());
-        }
-    }
+
+		if (shouldPersistStrippedDom) {
+			outputBuilder.persistDom(state.getName(), vertex.getStrippedDom());
+		} else {
+			outputBuilder
+					.persistDom(state.getName(), context.getBrowser().getDom());
+		}
+	}
 
 	private void saveScreenshot(EmbeddedBrowser browser, String name,
 	        StateVertex vertex) {
@@ -199,16 +199,16 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 		return result;
 	}
 
-    /**
-     * Sets whether full DOM should be stored to disk at <code>onNewState</code>,
-     * or the stripped DOM. Default is full DOM, i.e. <code>false</code>.
-     *
-     * @param persistStrippedDom
-     *            whether the stripped DOM should be stored
-     */
-    public void setShouldPersistStrippedDom(boolean persistStrippedDom) {
-        shouldPersistStrippedDom = persistStrippedDom;
-    }
+	/**
+	 * Sets whether full DOM should be stored to disk at <code>onNewState</code>,
+	 * or the stripped DOM. Default is full DOM, i.e. <code>false</code>.
+	 *
+	 * @param persistStrippedDom
+	 *            whether the stripped DOM should be stored
+	 */
+	public void setShouldPersistStrippedDom(boolean persistStrippedDom) {
+		shouldPersistStrippedDom = persistStrippedDom;
+	}
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
I made this small change to the CrawlOverview plugin in my local fork. I thought it was not practical for debugging that the plugin stores the browser's DOM instead of the vertex's strippedDom. And apart from debugging, I think the current behaviour is counter-intuitive: it is the stripped dom that determines whether we're dealing with a new state, so for me, that is the dom that should be stored.

The default behaviour is still the same, users can use the setter method on the plugin to change the behaviour. Up to you to decide whether you want to merge this :)
