### PR TITLE
DOM diff view in CrawlOverview

### DIFF
--- a/core/src/main/java/com/crawljax/domcomparators/DomStrippers.java
+++ b/core/src/main/java/com/crawljax/domcomparators/DomStrippers.java
@@ -35,7 +35,7 @@ public class DomStrippers {
 					document = applySafely(stripper, document);
 				}
 				// Apply changes to String representation
- +				dom = document.toString();
+ 				dom = document.toString();
 			}
 			for (DomStripper stripper : strippers) {
 				dom = applySafely(stripper, dom);

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/CrawlOverview.java
@@ -47,6 +47,7 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 	private final OutPutModelCache outModelCache;
 	private OutputBuilder outputBuilder;
 	private boolean warnedForElementsInIframe = false;
+	private boolean shouldPersistStrippedDom = false;
 
 	private OutPutModel result;
 
@@ -86,6 +87,12 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 		visitedStates.putIfAbsent(state.getName(), vertex);
 		saveScreenshot(context.getBrowser(), state.getName(), vertex);
 		outputBuilder.persistDom(state.getName(), context.getBrowser().getDom());
+		if (shouldPersistStrippedDom) {
+			outputBuilder.persistDom(state.getName(), vertex.getStrippedDom());
+		} else {
+			outputBuilder
+				.persistDom(state.getName(), context.getBrowser().getDom());
+		}
 	}
 
 	private void saveScreenshot(EmbeddedBrowser browser, String name,
@@ -103,6 +110,17 @@ public class CrawlOverview implements OnNewStatePlugin, PreStateCrawlingPlugin,
 			LOG.debug("Screenshot not made because {}", e.getMessage(), e);
 		}
 		LOG.trace("Screenshot saved");
+	}
+
+	/**
+	 * Sets whether full DOM should be stored to disk at <code>onNewState</code>,
+	 * or the stripped DOM. Default is full DOM, i.e. <code>false</code>.
+	 *
+	 * @param persistStrippedDom
+	 *            whether the stripped DOM should be stored
+	 */
+	public void setShouldPersistStrippedDom(boolean persistStrippedDom) {
+		shouldPersistStrippedDom = persistStrippedDom;
 	}
 
 	/**

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/StateWriter.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/StateWriter.java
@@ -52,8 +52,8 @@ class StateWriter {
 		}
 		context.put("failedEvents", failedEvents);
 		String dom = outBuilder.getDom(state.getName());
-		dom = StringEscapeUtils.escapeHtml4(dom);
-		context.put("dom", dom);
+		context.put("javascriptDom", StringEscapeUtils.escapeEcmaScript(dom));
+		context.put("dom", StringEscapeUtils.escapeHtml4(dom));
 
 		// writing
 		String name = state.getName();

--- a/plugins/crawloverview-plugin/src/main/resources/header.html
+++ b/plugins/crawloverview-plugin/src/main/resources/header.html
@@ -10,4 +10,13 @@
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 <!--[if lt IE 9]>
 	<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-	<![endif]-->
+<![endif]-->
+
+<!-- Scripts (and stylesheet) for state diff view -->
+	<link rel="stylesheet" type="text/css" href="$baseUrl/css/diffview.css"/>
+	<script type="text/javascript" src="$baseUrl/lib/jquery-2.0.3.min.js"></script>
+	<script type="text/javascript" src="$baseUrl/lib/diffview.js"></script>
+	<script type="text/javascript" src="$baseUrl/lib/difflib.js"></script>
+	<script type="text/javascript" src="$baseUrl/js/diffLoader.js"></script>
+	<script type="text/javascript" src="$baseUrl/lib/filereader.js"></script>
+

--- a/plugins/crawloverview-plugin/src/main/resources/skeleton/css/diffview.css
+++ b/plugins/crawloverview-plugin/src/main/resources/skeleton/css/diffview.css
@@ -1,0 +1,83 @@
+/*
+This is part of jsdifflib v1.0. <http://github.com/cemerick/jsdifflib>
+
+Copyright 2007 - 2011 Chas Emerick <cemerick@snowtide.com>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY Chas Emerick ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Chas Emerick OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of Chas Emerick.
+*/
+table.diff {
+	border-collapse:collapse;
+	border:1px solid darkgray;
+	white-space:pre-wrap
+}
+table.diff tbody { 
+	font-family:Courier, monospace
+}
+table.diff tbody th {
+	font-family:verdana,arial,'Bitstream Vera Sans',helvetica,sans-serif;
+	background:#EED;
+	font-size:11px;
+	font-weight:normal;
+	border:1px solid #BBC;
+	color:#886;
+	padding:.3em .5em .1em 2em;
+	text-align:right;
+	vertical-align:top
+}
+table.diff thead {
+	border-bottom:1px solid #BBC;
+	background:#EFEFEF;
+	font-family:Verdana
+}
+table.diff thead th.texttitle {
+	text-align:left
+}
+table.diff tbody td {
+	padding:0px .4em;
+	padding-top:.4em;
+	vertical-align:top;
+}
+table.diff .empty {
+	background-color:#DDD;
+}
+table.diff .replace {
+	background-color:#FD8
+}
+table.diff .delete {
+	background-color:#E99;
+}
+table.diff .skip {
+	background-color:#EFEFEF;
+	border:1px solid #AAA;
+	border-right:1px solid #BBC;
+}
+table.diff .insert {
+	background-color:#9E9
+}
+table.diff th.author {
+	text-align:right;
+	border-top:1px solid #BBC;
+	background:#EFEFEF
+}

--- a/plugins/crawloverview-plugin/src/main/resources/skeleton/js/diffLoader.js
+++ b/plugins/crawloverview-plugin/src/main/resources/skeleton/js/diffLoader.js
@@ -1,0 +1,132 @@
+/*
+ * diffLoader.js
+ * Functions to load and display the Dom diff view in the CrawlOverview state
+ * pages.
+ * author: Ivan Plantevin
+ */
+
+var diffLoader = {
+	/* Management of state browsing history */
+	updateStateHistoryWithDom: function(currentDom) {
+		// Current is now previous.
+		var previous = localStorage.getItem("currentState");
+		var current = diffLoader.fileName(location.href);
+
+		if (!previous) {
+			// No previous state, set to current.
+			localStorage.setItem("previousState", current);
+			localStorage.setItem("previousDom", currentDom);
+		} else if (previous != current) { // Don't diff itself (e.g. after reload)
+			localStorage.setItem("previousState", previous);
+			localStorage.setItem("previousDom", localStorage.getItem("currentDom"));
+		}
+
+		localStorage.setItem("currentState", current);
+		localStorage.setItem("currentDom", currentDom);
+		console.log("previous: " + localStorage.getItem("previousState"));
+		console.log("current: " + localStorage.getItem("currentState"));
+	},
+
+	/* Only loads the diff if it hasn't been loaded yet */
+	initDiff: function() {
+		if (diffLoader.diffIsNotYetLoaded()) {
+			console.log("Calculating and loading diff");
+			diffLoader.loadDomDiff();
+		}
+	},
+
+	diffIsNotYetLoaded: function() {
+		return $("#diffOutput").html() == "";
+	},
+
+	/*
+	 * Loads doms from localStorage and displays the diff.
+	 */
+	loadDomDiff: function() {
+		$("#diffOutput").html("Loading diff...");
+		// Default inline view (1) and context size of 4
+		var viewType = 1,
+			contextSize = 4,
+			dom1 = localStorage.getItem("previousDom"),
+			dom2 = localStorage.getItem("currentDom"),
+			state1 = localStorage.getItem("previousState"),
+			state2 = localStorage.getItem("currentState");
+		diffLoader.showStringsDiff(dom1, dom2, viewType, contextSize, state1, state2);
+	},
+
+	/*
+	 * Calls the jsdifflib functions to actually calculate and display the
+	 * diff.
+	 */
+	showStringsDiff: function(text1, text2, viewType, contextSize, name1, name2) {
+		var lines1 = difflib.stringAsLines(text1),
+			lines2 = difflib.stringAsLines(text2),
+			sequenceMatcher = new difflib.SequenceMatcher(lines1, lines2),
+			opcodes = sequenceMatcher.get_opcodes(),
+			diffOutputDiv = document.getElementById("diffOutput");
+
+		contextSize = contextSize || null;
+		name1 = name1 || "Base Text";
+		name2 = name2 || "New Text";
+
+		diffOutputDiv.innerHTML = "";
+		diffOutputDiv.appendChild(diffview.buildView({
+			baseTextLines: lines1,
+			newTextLines: lines2,
+			opcodes: opcodes,
+			baseTextName: name1,
+			newTextName: name2,
+			contextSize: contextSize,
+			viewType: viewType
+		}));
+
+		diffLoader.makeDiffTitleClickable(name1, name2);
+	},
+
+	/*
+	 * jsdifflib escapes the state names, so to make them clickable we insert
+	 * own html to link titles in the diff table to their respective pages.
+	 */
+	makeDiffTitleClickable: function(state1, state2) {
+		var hyperlinkedTextTitle =
+			'<a title="Open in new window" target="_blank" href="' + state1 +
+			'">' + state1 + '</a> vs. ' +
+			'<a title="Open in new window" target="_blank" href="' + state2 +
+			'">' + state2 + '</a>';
+		$(".texttitle").first().html(hyperlinkedTextTitle);
+	},
+
+	fileName: function(fullPath) {
+		var fileNameIndex = fullPath.lastIndexOf("/") + 1;
+		return fullPath.substring(fileNameIndex);
+	},
+
+	/*
+	 * Adds listeners for the two file inputs in the Dom diff view.
+	 */
+	setupFileInputListeners: function() {
+		var file1 = document.getElementById("diffFile1");
+		FileReaderJS.setupInput(file1, {
+			readAsDefault: "Text",
+			on: {
+				load: function(e, file) {
+					localStorage.setItem("previousDom", e.target.result);
+					localStorage.setItem("previousState", file.name);
+					diffLoader.loadDomDiff();
+				}
+			}
+		});
+
+		var file2 = document.getElementById("diffFile2");
+		FileReaderJS.setupInput(file2, {
+			readAsDefault: "Text",
+			on: {
+				load: function(e, file) {
+					localStorage.setItem("currentDom", e.target.result);
+					localStorage.setItem("currentState", file.name);
+					diffLoader.loadDomDiff();
+			}
+			}
+		});
+	}
+} // End diffLoader

--- a/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/difflib.js
+++ b/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/difflib.js
@@ -1,0 +1,410 @@
+/***
+This is part of jsdifflib v1.0. <http://snowtide.com/jsdifflib>
+
+Copyright (c) 2007, Snowtide Informatics Systems, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this
+		list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice,
+		this list of conditions and the following disclaimer in the documentation
+		and/or other materials provided with the distribution.
+	* Neither the name of the Snowtide Informatics Systems nor the names of its
+		contributors may be used to endorse or promote products derived from this
+		software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+***/
+/* Author: Chas Emerick <cemerick@snowtide.com> */
+__whitespace = {" ":true, "\t":true, "\n":true, "\f":true, "\r":true};
+
+difflib = {
+	defaultJunkFunction: function (c) {
+		return __whitespace.hasOwnProperty(c);
+	},
+	
+	stripLinebreaks: function (str) { return str.replace(/^[\n\r]*|[\n\r]*$/g, ""); },
+	
+	stringAsLines: function (str) {
+		var lfpos = str.indexOf("\n");
+		var crpos = str.indexOf("\r");
+		var linebreak = ((lfpos > -1 && crpos > -1) || crpos < 0) ? "\n" : "\r";
+		
+		var lines = str.split(linebreak);
+		for (var i = 0; i < lines.length; i++) {
+			lines[i] = difflib.stripLinebreaks(lines[i]);
+		}
+		
+		return lines;
+	},
+	
+	// iteration-based reduce implementation
+	__reduce: function (func, list, initial) {
+		if (initial != null) {
+			var value = initial;
+			var idx = 0;
+		} else if (list) {
+			var value = list[0];
+			var idx = 1;
+		} else {
+			return null;
+		}
+		
+		for (; idx < list.length; idx++) {
+			value = func(value, list[idx]);
+		}
+		
+		return value;
+	},
+	
+	// comparison function for sorting lists of numeric tuples
+	__ntuplecomp: function (a, b) {
+		var mlen = Math.max(a.length, b.length);
+		for (var i = 0; i < mlen; i++) {
+			if (a[i] < b[i]) return -1;
+			if (a[i] > b[i]) return 1;
+		}
+		
+		return a.length == b.length ? 0 : (a.length < b.length ? -1 : 1);
+	},
+	
+	__calculate_ratio: function (matches, length) {
+		return length ? 2.0 * matches / length : 1.0;
+	},
+	
+	// returns a function that returns true if a key passed to the returned function
+	// is in the dict (js object) provided to this function; replaces being able to
+	// carry around dict.has_key in python...
+	__isindict: function (dict) {
+		return function (key) { return dict.hasOwnProperty(key); };
+	},
+	
+	// replacement for python's dict.get function -- need easy default values
+	__dictget: function (dict, key, defaultValue) {
+		return dict.hasOwnProperty(key) ? dict[key] : defaultValue;
+	},	
+	
+	SequenceMatcher: function (a, b, isjunk) {
+		this.set_seqs = function (a, b) {
+			this.set_seq1(a);
+			this.set_seq2(b);
+		}
+		
+		this.set_seq1 = function (a) {
+			if (a == this.a) return;
+			this.a = a;
+			this.matching_blocks = this.opcodes = null;
+		}
+		
+		this.set_seq2 = function (b) {
+			if (b == this.b) return;
+			this.b = b;
+			this.matching_blocks = this.opcodes = this.fullbcount = null;
+			this.__chain_b();
+		}
+		
+		this.__chain_b = function () {
+			var b = this.b;
+			var n = b.length;
+			var b2j = this.b2j = {};
+			var populardict = {};
+			for (var i = 0; i < b.length; i++) {
+				var elt = b[i];
+				if (b2j.hasOwnProperty(elt)) {
+					var indices = b2j[elt];
+					if (n >= 200 && indices.length * 100 > n) {
+						populardict[elt] = 1;
+						delete b2j[elt];
+					} else {
+						indices.push(i);
+					}
+				} else {
+					b2j[elt] = [i];
+				}
+			}
+	
+			for (var elt in populardict) {
+				if (populardict.hasOwnProperty(elt)) {
+					delete b2j[elt];
+				}
+			}
+			
+			var isjunk = this.isjunk;
+			var junkdict = {};
+			if (isjunk) {
+				for (var elt in populardict) {
+					if (populardict.hasOwnProperty(elt) && isjunk(elt)) {
+						junkdict[elt] = 1;
+						delete populardict[elt];
+					}
+				}
+				for (var elt in b2j) {
+					if (b2j.hasOwnProperty(elt) && isjunk(elt)) {
+						junkdict[elt] = 1;
+						delete b2j[elt];
+					}
+				}
+			}
+	
+			this.isbjunk = difflib.__isindict(junkdict);
+			this.isbpopular = difflib.__isindict(populardict);
+		}
+		
+		this.find_longest_match = function (alo, ahi, blo, bhi) {
+			var a = this.a;
+			var b = this.b;
+			var b2j = this.b2j;
+			var isbjunk = this.isbjunk;
+			var besti = alo;
+			var bestj = blo;
+			var bestsize = 0;
+			var j = null;
+	
+			var j2len = {};
+			var nothing = [];
+			for (var i = alo; i < ahi; i++) {
+				var newj2len = {};
+				var jdict = difflib.__dictget(b2j, a[i], nothing);
+				for (var jkey in jdict) {
+					if (jdict.hasOwnProperty(jkey)) {
+						j = jdict[jkey];
+						if (j < blo) continue;
+						if (j >= bhi) break;
+						newj2len[j] = k = difflib.__dictget(j2len, j - 1, 0) + 1;
+						if (k > bestsize) {
+							besti = i - k + 1;
+							bestj = j - k + 1;
+							bestsize = k;
+						}
+					}
+				}
+				j2len = newj2len;
+			}
+	
+			while (besti > alo && bestj > blo && !isbjunk(b[bestj - 1]) && a[besti - 1] == b[bestj - 1]) {
+				besti--;
+				bestj--;
+				bestsize++;
+			}
+				
+			while (besti + bestsize < ahi && bestj + bestsize < bhi &&
+					!isbjunk(b[bestj + bestsize]) &&
+					a[besti + bestsize] == b[bestj + bestsize]) {
+				bestsize++;
+			}
+	
+			while (besti > alo && bestj > blo && isbjunk(b[bestj - 1]) && a[besti - 1] == b[bestj - 1]) {
+				besti--;
+				bestj--;
+				bestsize++;
+			}
+			
+			while (besti + bestsize < ahi && bestj + bestsize < bhi && isbjunk(b[bestj + bestsize]) &&
+					a[besti + bestsize] == b[bestj + bestsize]) {
+				bestsize++;
+			}
+	
+			return [besti, bestj, bestsize];
+		}
+		
+		this.get_matching_blocks = function () {
+			if (this.matching_blocks != null) return this.matching_blocks;
+			var la = this.a.length;
+			var lb = this.b.length;
+	
+			var queue = [[0, la, 0, lb]];
+			var matching_blocks = [];
+			var alo, ahi, blo, bhi, qi, i, j, k, x;
+			while (queue.length) {
+				qi = queue.pop();
+				alo = qi[0];
+				ahi = qi[1];
+				blo = qi[2];
+				bhi = qi[3];
+				x = this.find_longest_match(alo, ahi, blo, bhi);
+				i = x[0];
+				j = x[1];
+				k = x[2];
+	
+				if (k) {
+					matching_blocks.push(x);
+					if (alo < i && blo < j)
+						queue.push([alo, i, blo, j]);
+					if (i+k < ahi && j+k < bhi)
+						queue.push([i + k, ahi, j + k, bhi]);
+				}
+			}
+			
+			matching_blocks.sort(difflib.__ntuplecomp);
+	
+			var i1 = j1 = k1 = block = 0;
+			var non_adjacent = [];
+			for (var idx in matching_blocks) {
+				if (matching_blocks.hasOwnProperty(idx)) {
+					block = matching_blocks[idx];
+					i2 = block[0];
+					j2 = block[1];
+					k2 = block[2];
+					if (i1 + k1 == i2 && j1 + k1 == j2) {
+						k1 += k2;
+					} else {
+						if (k1) non_adjacent.push([i1, j1, k1]);
+						i1 = i2;
+						j1 = j2;
+						k1 = k2;
+					}
+				}
+			}
+			
+			if (k1) non_adjacent.push([i1, j1, k1]);
+	
+			non_adjacent.push([la, lb, 0]);
+			this.matching_blocks = non_adjacent;
+			return this.matching_blocks;
+		}
+		
+		this.get_opcodes = function () {
+			if (this.opcodes != null) return this.opcodes;
+			var i = 0;
+			var j = 0;
+			var answer = [];
+			this.opcodes = answer;
+			var block, ai, bj, size, tag;
+			var blocks = this.get_matching_blocks();
+			for (var idx in blocks) {
+				if (blocks.hasOwnProperty(idx)) {
+					block = blocks[idx];
+					ai = block[0];
+					bj = block[1];
+					size = block[2];
+					tag = '';
+					if (i < ai && j < bj) {
+						tag = 'replace';
+					} else if (i < ai) {
+						tag = 'delete';
+					} else if (j < bj) {
+						tag = 'insert';
+					}
+					if (tag) answer.push([tag, i, ai, j, bj]);
+					i = ai + size;
+					j = bj + size;
+					
+					if (size) answer.push(['equal', ai, i, bj, j]);
+				}
+			}
+			
+			return answer;
+		}
+		
+		// this is a generator function in the python lib, which of course is not supported in javascript
+		// the reimplementation builds up the grouped opcodes into a list in their entirety and returns that.
+		this.get_grouped_opcodes = function (n) {
+			if (!n) n = 3;
+			var codes = this.get_opcodes();
+			if (!codes) codes = [["equal", 0, 1, 0, 1]];
+			var code, tag, i1, i2, j1, j2;
+			if (codes[0][0] == 'equal') {
+				code = codes[0];
+				tag = code[0];
+				i1 = code[1];
+				i2 = code[2];
+				j1 = code[3];
+				j2 = code[4];
+				codes[0] = [tag, Math.max(i1, i2 - n), i2, Math.max(j1, j2 - n), j2];
+			}
+			if (codes[codes.length - 1][0] == 'equal') {
+				code = codes[codes.length - 1];
+				tag = code[0];
+				i1 = code[1];
+				i2 = code[2];
+				j1 = code[3];
+				j2 = code[4];
+				codes[codes.length - 1] = [tag, i1, Math.min(i2, i1 + n), j1, Math.min(j2, j1 + n)];
+			}
+	
+			var nn = n + n;
+			var group = [];
+			var groups = [];
+			for (var idx in codes) {
+				if (codes.hasOwnProperty(idx)) {
+					code = codes[idx];
+					tag = code[0];
+					i1 = code[1];
+					i2 = code[2];
+					j1 = code[3];
+					j2 = code[4];
+					if (tag == 'equal' && i2 - i1 > nn) {
+						group.push([tag, i1, Math.min(i2, i1 + n), j1, Math.min(j2, j1 + n)]);
+						groups.push(group);
+						group = [];
+						i1 = Math.max(i1, i2-n);
+						j1 = Math.max(j1, j2-n);
+					}
+					
+					group.push([tag, i1, i2, j1, j2]);
+				}
+			}
+			
+			if (group && !(group.length == 1 && group[0][0] == 'equal')) groups.push(group)
+			
+			return groups;
+		}
+		
+		this.ratio = function () {
+			matches = difflib.__reduce(
+							function (sum, triple) { return sum + triple[triple.length - 1]; },
+							this.get_matching_blocks(), 0);
+			return difflib.__calculate_ratio(matches, this.a.length + this.b.length);
+		}
+		
+		this.quick_ratio = function () {
+			var fullbcount, elt;
+			if (this.fullbcount == null) {
+				this.fullbcount = fullbcount = {};
+				for (var i = 0; i < this.b.length; i++) {
+					elt = this.b[i];
+					fullbcount[elt] = difflib.__dictget(fullbcount, elt, 0) + 1;
+				}
+			}
+			fullbcount = this.fullbcount;
+	
+			var avail = {};
+			var availhas = difflib.__isindict(avail);
+			var matches = numb = 0;
+			for (var i = 0; i < this.a.length; i++) {
+				elt = this.a[i];
+				if (availhas(elt)) {
+					numb = avail[elt];
+				} else {
+					numb = difflib.__dictget(fullbcount, elt, 0);
+				}
+				avail[elt] = numb - 1;
+				if (numb > 0) matches++;
+			}
+			
+			return difflib.__calculate_ratio(matches, this.a.length + this.b.length);
+		}
+		
+		this.real_quick_ratio = function () {
+			var la = this.a.length;
+			var lb = this.b.length;
+			return _calculate_ratio(Math.min(la, lb), la + lb);
+		}
+		
+		this.isjunk = isjunk ? isjunk : difflib.defaultJunkFunction;
+		this.a = this.b = null;
+		this.set_seqs(a, b);
+	}
+};

--- a/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/diffview.js
+++ b/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/diffview.js
@@ -1,0 +1,198 @@
+/*
+This is part of jsdifflib v1.0. <http://github.com/cemerick/jsdifflib>
+
+Copyright 2007 - 2011 Chas Emerick <cemerick@snowtide.com>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY Chas Emerick ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Chas Emerick OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of Chas Emerick.
+*/
+diffview = {
+	/**
+	 * Builds and returns a visual diff view.  The single parameter, `params', should contain
+	 * the following values:
+	 *
+	 * - baseTextLines: the array of strings that was used as the base text input to SequenceMatcher
+	 * - newTextLines: the array of strings that was used as the new text input to SequenceMatcher
+	 * - opcodes: the array of arrays returned by SequenceMatcher.get_opcodes()
+	 * - baseTextName: the title to be displayed above the base text listing in the diff view; defaults
+	 *	   to "Base Text"
+	 * - newTextName: the title to be displayed above the new text listing in the diff view; defaults
+	 *	   to "New Text"
+	 * - contextSize: the number of lines of context to show around differences; by default, all lines
+	 *	   are shown
+	 * - viewType: if 0, a side-by-side diff view is generated (default); if 1, an inline diff view is
+	 *	   generated
+	 */
+	buildView: function (params) {
+		var baseTextLines = params.baseTextLines;
+		var newTextLines = params.newTextLines;
+		var opcodes = params.opcodes;
+		var baseTextName = params.baseTextName ? params.baseTextName : "Base Text";
+		var newTextName = params.newTextName ? params.newTextName : "New Text";
+		var contextSize = params.contextSize;
+		var inline = (params.viewType == 0 || params.viewType == 1) ? params.viewType : 0;
+
+		if (baseTextLines == null)
+			throw "Cannot build diff view; baseTextLines is not defined.";
+		if (newTextLines == null)
+			throw "Cannot build diff view; newTextLines is not defined.";
+		if (!opcodes)
+			throw "Canno build diff view; opcodes is not defined.";
+		
+		function celt (name, clazz) {
+			var e = document.createElement(name);
+			e.className = clazz;
+			return e;
+		}
+		
+		function telt (name, text) {
+			var e = document.createElement(name);
+			e.appendChild(document.createTextNode(text));
+			return e;
+		}
+		
+		function ctelt (name, clazz, text) {
+			var e = document.createElement(name);
+			e.className = clazz;
+			e.appendChild(document.createTextNode(text));
+			return e;
+		}
+	
+		var tdata = document.createElement("thead");
+		var node = document.createElement("tr");
+		tdata.appendChild(node);
+		if (inline) {
+			node.appendChild(document.createElement("th"));
+			node.appendChild(document.createElement("th"));
+			node.appendChild(ctelt("th", "texttitle", baseTextName + " vs. " + newTextName));
+		} else {
+			node.appendChild(document.createElement("th"));
+			node.appendChild(ctelt("th", "texttitle", baseTextName));
+			node.appendChild(document.createElement("th"));
+			node.appendChild(ctelt("th", "texttitle", newTextName));
+		}
+		tdata = [tdata];
+		
+		var rows = [];
+		var node2;
+		
+		/**
+		 * Adds two cells to the given row; if the given row corresponds to a real
+		 * line number (based on the line index tidx and the endpoint of the 
+		 * range in question tend), then the cells will contain the line number
+		 * and the line of text from textLines at position tidx (with the class of
+		 * the second cell set to the name of the change represented), and tidx + 1 will
+		 * be returned.	 Otherwise, tidx is returned, and two empty cells are added
+		 * to the given row.
+		 */
+		function addCells (row, tidx, tend, textLines, change) {
+			if (tidx < tend) {
+				row.appendChild(telt("th", (tidx + 1).toString()));
+				row.appendChild(ctelt("td", change, textLines[tidx].replace(/\t/g, "\u00a0\u00a0\u00a0\u00a0")));
+				return tidx + 1;
+			} else {
+				row.appendChild(document.createElement("th"));
+				row.appendChild(celt("td", "empty"));
+				return tidx;
+			}
+		}
+		
+		function addCellsInline (row, tidx, tidx2, textLines, change) {
+			row.appendChild(telt("th", tidx == null ? "" : (tidx + 1).toString()));
+			row.appendChild(telt("th", tidx2 == null ? "" : (tidx2 + 1).toString()));
+			row.appendChild(ctelt("td", change, textLines[tidx != null ? tidx : tidx2].replace(/\t/g, "\u00a0\u00a0\u00a0\u00a0")));
+		}
+		
+		for (var idx = 0; idx < opcodes.length; idx++) {
+			code = opcodes[idx];
+			change = code[0];
+			var b = code[1];
+			var be = code[2];
+			var n = code[3];
+			var ne = code[4];
+			var rowcnt = Math.max(be - b, ne - n);
+			var toprows = [];
+			var botrows = [];
+			for (var i = 0; i < rowcnt; i++) {
+				// jump ahead if we've alredy provided leading context or if this is the first range
+				if (contextSize && opcodes.length > 1 && ((idx > 0 && i == contextSize) || (idx == 0 && i == 0)) && change=="equal") {
+					var jump = rowcnt - ((idx == 0 ? 1 : 2) * contextSize);
+					if (jump > 1) {
+						toprows.push(node = document.createElement("tr"));
+						
+						b += jump;
+						n += jump;
+						i += jump - 1;
+						node.appendChild(telt("th", "..."));
+						if (!inline) node.appendChild(ctelt("td", "skip", ""));
+						node.appendChild(telt("th", "..."));
+						node.appendChild(ctelt("td", "skip", ""));
+						
+						// skip last lines if they're all equal
+						if (idx + 1 == opcodes.length) {
+							break;
+						} else {
+							continue;
+						}
+					}
+				}
+				
+				toprows.push(node = document.createElement("tr"));
+				if (inline) {
+					if (change == "insert") {
+						addCellsInline(node, null, n++, newTextLines, change);
+					} else if (change == "replace") {
+						botrows.push(node2 = document.createElement("tr"));
+						if (b < be) addCellsInline(node, b++, null, baseTextLines, "delete");
+						if (n < ne) addCellsInline(node2, null, n++, newTextLines, "insert");
+					} else if (change == "delete") {
+						addCellsInline(node, b++, null, baseTextLines, change);
+					} else {
+						// equal
+						addCellsInline(node, b++, n++, baseTextLines, change);
+					}
+				} else {
+					b = addCells(node, b, be, baseTextLines, change);
+					n = addCells(node, n, ne, newTextLines, change);
+				}
+			}
+
+			for (var i = 0; i < toprows.length; i++) rows.push(toprows[i]);
+			for (var i = 0; i < botrows.length; i++) rows.push(botrows[i]);
+		}
+		
+		rows.push(node = ctelt("th", "author", "diff view generated by "));
+		node.setAttribute("colspan", inline ? 3 : 4);
+		node.appendChild(node2 = telt("a", "jsdifflib"));
+		node2.setAttribute("href", "http://github.com/cemerick/jsdifflib");
+		
+		tdata.push(node = document.createElement("tbody"));
+		for (var idx in rows) rows.hasOwnProperty(idx) && node.appendChild(rows[idx]);
+		
+		node = celt("table", "diff" + (inline ? " inlinediff" : ""));
+		for (var idx in tdata) tdata.hasOwnProperty(idx) && node.appendChild(tdata[idx]);
+		return node;
+	}
+};
+

--- a/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/filereader.js
+++ b/plugins/crawloverview-plugin/src/main/resources/skeleton/lib/filereader.js
@@ -1,0 +1,432 @@
+/*!
+FileReader.js - v0.99
+A lightweight wrapper for common FileReader usage.
+Copyright 2014 Brian Grinstead - MIT License.
+See http://github.com/bgrins/filereader.js for documentation.
+*/
+
+(function(window, document) {
+
+    var FileReader = window.FileReader;
+    var FileReaderSyncSupport = false;
+    var workerScript = "self.addEventListener('message', function(e) { var data=e.data; try { var reader = new FileReaderSync; postMessage({ result: reader[data.readAs](data.file), extra: data.extra, file: data.file})} catch(e){ postMessage({ result:'error', extra:data.extra, file:data.file}); } }, false);";
+    var syncDetectionScript = "onmessage = function(e) { postMessage(!!FileReaderSync); };";
+    var fileReaderEvents = ['loadstart', 'progress', 'load', 'abort', 'error', 'loadend'];
+    var sync = false;
+    var FileReaderJS = window.FileReaderJS = {
+        enabled: false,
+        setupInput: setupInput,
+        setupDrop: setupDrop,
+        setupClipboard: setupClipboard,
+        setSync: function (value) {
+            sync = value;
+
+            if (sync && !FileReaderSyncSupport) {
+                checkFileReaderSyncSupport();
+            }
+        },
+        getSync: function() {
+            return sync && FileReaderSyncSupport;
+        },
+        output: [],
+        opts: {
+            dragClass: "drag",
+            accept: false,
+            readAsDefault: 'DataURL',
+            readAsMap: {
+            },
+            on: {
+                loadstart: noop,
+                progress: noop,
+                load: noop,
+                abort: noop,
+                error: noop,
+                loadend: noop,
+                skip: noop,
+                groupstart: noop,
+                groupend: noop,
+                beforestart: noop
+            }
+        }
+    };
+
+    // Setup jQuery plugin (if available)
+    if (typeof(jQuery) !== "undefined") {
+        jQuery.fn.fileReaderJS = function(opts) {
+            return this.each(function() {
+                if (jQuery(this).is("input")) {
+                    setupInput(this, opts);
+                }
+                else {
+                    setupDrop(this, opts);
+                }
+            });
+        };
+
+        jQuery.fn.fileClipboard = function(opts) {
+            return this.each(function() {
+                setupClipboard(this, opts);
+            });
+        };
+    }
+
+    // Not all browsers support the FileReader interface. Return with the enabled bit = false.
+    if (!FileReader) {
+        return;
+    }
+
+
+    // makeWorker is a little wrapper for generating web workers from strings
+    function makeWorker(script) {
+        var URL = window.URL || window.webkitURL;
+        var Blob = window.Blob;
+        var Worker = window.Worker;
+
+        if (!URL || !Blob || !Worker || !script) {
+            return null;
+        }
+
+        var blob = new Blob([script]);
+        var worker = new Worker(URL.createObjectURL(blob));
+        return worker;
+    }
+
+    // setupClipboard: bind to clipboard events (intended for document.body)
+    function setupClipboard(element, opts) {
+
+        if (!FileReaderJS.enabled) {
+            return;
+        }
+        var instanceOptions = extend(extend({}, FileReaderJS.opts), opts);
+
+        element.addEventListener("paste", onpaste, false);
+
+        function onpaste(e) {
+            var files = [];
+            var clipboardData = e.clipboardData || {};
+            var items = clipboardData.items || [];
+
+            for (var i = 0; i < items.length; i++) {
+                var file = items[i].getAsFile();
+
+                if (file) {
+
+                    // Create a fake file name for images from clipboard, since this data doesn't get sent
+                    var matches = new RegExp("/\(.*\)").exec(file.type);
+                    if (!file.name && matches) {
+                        var extension = matches[1];
+                        file.name = "clipboard" + i + "." + extension;
+                    }
+
+                    files.push(file);
+                }
+            }
+
+            if (files.length) {
+                processFileList(e, files, instanceOptions);
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        }
+    }
+
+    // setupInput: bind the 'change' event to an input[type=file]
+    function setupInput(input, opts) {
+
+        if (!FileReaderJS.enabled) {
+            return;
+        }
+        var instanceOptions = extend(extend({}, FileReaderJS.opts), opts);
+
+        input.addEventListener("change", inputChange, false);
+        input.addEventListener("drop", inputDrop, false);
+
+        function inputChange(e) {
+            processFileList(e, input.files, instanceOptions);
+        }
+
+        function inputDrop(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            processFileList(e, e.dataTransfer.files, instanceOptions);
+        }
+    }
+
+    // setupDrop: bind the 'drop' event for a DOM element
+    function setupDrop(dropbox, opts) {
+
+        if (!FileReaderJS.enabled) {
+            return;
+        }
+        var instanceOptions = extend(extend({}, FileReaderJS.opts), opts);
+        var dragClass = instanceOptions.dragClass;
+        var initializedOnBody = false;
+
+        // Bind drag events to the dropbox to add the class while dragging, and accept the drop data transfer.
+        dropbox.addEventListener("dragenter", onlyWithFiles(dragenter), false);
+        dropbox.addEventListener("dragleave", onlyWithFiles(dragleave), false);
+        dropbox.addEventListener("dragover", onlyWithFiles(dragover), false);
+        dropbox.addEventListener("drop", onlyWithFiles(drop), false);
+
+        // Bind to body to prevent the dropbox events from firing when it was initialized on the page.
+        document.body.addEventListener("dragstart", bodydragstart, true);
+        document.body.addEventListener("dragend", bodydragend, true);
+        document.body.addEventListener("drop", bodydrop, false);
+
+        function bodydragend(e) {
+            initializedOnBody = false;
+        }
+
+        function bodydragstart(e) {
+            initializedOnBody = true;
+        }
+
+        function bodydrop(e) {
+            if (e.dataTransfer.files && e.dataTransfer.files.length ){
+                e.stopPropagation();
+                e.preventDefault();
+            }
+        }
+
+        function onlyWithFiles(fn) {
+            return function() {
+                if (!initializedOnBody) {
+                    fn.apply(this, arguments);
+                }
+            };
+        }
+
+        function drop(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            if (dragClass) {
+                removeClass(dropbox, dragClass);
+            }
+            processFileList(e, e.dataTransfer.files, instanceOptions);
+        }
+
+        function dragenter(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            if (dragClass) {
+                addClass(dropbox, dragClass);
+            }
+        }
+
+        function dragleave(e) {
+            if (dragClass) {
+                removeClass(dropbox, dragClass);
+            }
+        }
+
+        function dragover(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            if (dragClass) {
+                addClass(dropbox, dragClass);
+            }
+        }
+    }
+
+    // setupCustomFileProperties: modify the file object with extra properties
+    function setupCustomFileProperties(files, groupID) {
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
+            file.extra = {
+                nameNoExtension: file.name.substring(0, file.name.lastIndexOf('.')),
+                extension: file.name.substring(file.name.lastIndexOf('.') + 1),
+                fileID: i,
+                uniqueID: getUniqueID(),
+                groupID: groupID,
+                prettySize: prettySize(file.size)
+            };
+        }
+    }
+
+    // getReadAsMethod: return method name for 'readAs*' - http://www.w3.org/TR/FileAPI/#reading-a-file
+    function getReadAsMethod(type, readAsMap, readAsDefault) {
+        for (var r in readAsMap) {
+            if (type.match(new RegExp(r))) {
+                return 'readAs' + readAsMap[r];
+            }
+        }
+        return 'readAs' + readAsDefault;
+    }
+
+    // processFileList: read the files with FileReader, send off custom events.
+    function processFileList(e, files, opts) {
+
+        var filesLeft = files.length;
+        var group = {
+            groupID: getGroupID(),
+            files: files,
+            started: new Date()
+        };
+
+        function groupEnd() {
+            group.ended = new Date();
+            opts.on.groupend(group);
+        }
+
+        function groupFileDone() {
+            if (--filesLeft === 0) {
+                groupEnd();
+            }
+        }
+
+        FileReaderJS.output.push(group);
+        setupCustomFileProperties(files, group.groupID);
+
+        opts.on.groupstart(group);
+
+        // No files in group - end immediately
+        if (!files.length) {
+            groupEnd();
+            return;
+        }
+
+        var supportsSync = sync && FileReaderSyncSupport;
+        var syncWorker;
+
+        // Only initialize the synchronous worker if the option is enabled - to prevent the overhead
+        if (supportsSync) {
+            syncWorker = makeWorker(workerScript);
+            syncWorker.onmessage = function(e) {
+                var file = e.data.file;
+                var result = e.data.result;
+
+                // Workers seem to lose the custom property on the file object.
+                if (!file.extra) {
+                    file.extra = e.data.extra;
+                }
+
+                file.extra.ended = new Date();
+
+                // Call error or load event depending on success of the read from the worker.
+                opts.on[result === "error" ? "error" : "load"]({ target: { result: result } }, file);
+                groupFileDone();
+            };
+        }
+
+        Array.prototype.forEach.call(files, function(file) {
+
+            file.extra.started = new Date();
+
+            if (opts.accept && !file.type.match(new RegExp(opts.accept))) {
+                opts.on.skip(file);
+                groupFileDone();
+                return;
+            }
+
+            if (opts.on.beforestart(file) === false) {
+                opts.on.skip(file);
+                groupFileDone();
+                return;
+            }
+
+            var readAs = getReadAsMethod(file.type, opts.readAsMap, opts.readAsDefault);
+
+            if (syncWorker) {
+                syncWorker.postMessage({
+                    file: file,
+                    extra: file.extra,
+                    readAs: readAs
+                });
+            }
+            else {
+
+                var reader = new FileReader();
+                reader.originalEvent = e;
+
+                fileReaderEvents.forEach(function(eventName) {
+                    reader['on' + eventName] = function(e) {
+                        if (eventName == 'load' || eventName == 'error') {
+                            file.extra.ended = new Date();
+                        }
+                        opts.on[eventName](e, file);
+                        if (eventName == 'loadend') {
+                            groupFileDone();
+                        }
+                    };
+                });
+                reader[readAs](file);
+            }
+        });
+    }
+
+    // checkFileReaderSyncSupport: Create a temporary worker and see if FileReaderSync exists
+    function checkFileReaderSyncSupport() {
+        var worker = makeWorker(syncDetectionScript);
+        if (worker) {
+            worker.onmessage =function(e) {
+                FileReaderSyncSupport = e.data;
+            };
+            worker.postMessage({});
+        }
+    }
+
+    // noop: do nothing
+    function noop() {
+
+    }
+
+    // extend: used to make deep copies of options object
+    function extend(destination, source) {
+        for (var property in source) {
+            if (source[property] && source[property].constructor &&
+                source[property].constructor === Object) {
+                destination[property] = destination[property] || {};
+                arguments.callee(destination[property], source[property]);
+            }
+            else {
+                destination[property] = source[property];
+            }
+        }
+        return destination;
+    }
+
+    // hasClass: does an element have the css class?
+    function hasClass(el, name) {
+        return new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)").test(el.className);
+    }
+
+    // addClass: add the css class for the element.
+    function addClass(el, name) {
+        if (!hasClass(el, name)) {
+          el.className = el.className ? [el.className, name].join(' ') : name;
+        }
+    }
+
+    // removeClass: remove the css class from the element.
+    function removeClass(el, name) {
+        if (hasClass(el, name)) {
+          var c = el.className;
+          el.className = c.replace(new RegExp("(?:^|\\s+)" + name + "(?:\\s+|$)", "g"), " ").replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+        }
+    }
+
+    // prettySize: convert bytes to a more readable string.
+    function prettySize(bytes) {
+        var s = ['bytes', 'kb', 'MB', 'GB', 'TB', 'PB'];
+        var e = Math.floor(Math.log(bytes)/Math.log(1024));
+        return (bytes/Math.pow(1024, Math.floor(e))).toFixed(2)+" "+s[e];
+    }
+
+    // getGroupID: generate a unique int ID for groups.
+    var getGroupID = (function(id) {
+        return function() {
+            return id++;
+        };
+    })(0);
+
+    // getUniqueID: generate a unique int ID for files
+    var getUniqueID = (function(id) {
+        return function() {
+            return id++;
+        };
+    })(0);
+
+    // The interface is supported, bind the FileReaderJS callbacks
+    FileReaderJS.enabled = true;
+
+})(this, document);

--- a/plugins/crawloverview-plugin/src/main/resources/state.html
+++ b/plugins/crawloverview-plugin/src/main/resources/state.html
@@ -45,6 +45,7 @@ body {
 					<td>${failedEvents}</td>
 			</tbody>
 		</table>
+
 		<ul id='tabs' class="nav nav-tabs">
 			<li class="active">
 				<a href="#screenshot">Screenshot</a>
@@ -54,7 +55,10 @@ body {
 			</li>	
 			<li>
 				<a href="#interactions">Interactions</a>
-			</li>			
+			</li>
+			<li>
+				<a href="#diff" onclick="diffLoader.initDiff()">DOM diff</a>
+			</li>
 		</ul>
 		<div class="tab-content">
 			<div class="tab-pane active" style="position: relative;" id='screenshot'>			
@@ -74,7 +78,7 @@ body {
 					<tbody>
 						<tr>
 							<th>Xpath</th>
-							<th>Destination</tg>
+							<th>Destination</th>
 						</tr>
 						#foreach( $element in $elements )
 						<tr>
@@ -84,6 +88,18 @@ body {
 						#end						
 					</tbody>
 				</table>
+			</div>
+			<div class="tab-pane" id="diff">
+				<div>Or select other file(s) to compare:&nbsp;&nbsp;
+					<input type="file" id="diffFile1">&nbsp;&nbsp;
+					<input type="file" id="diffFile2">
+				</div>
+				<br>
+				<div id="diffOutput"></div>
+				<br>
+				<a href="javascript:void(0);" onclick="diffLoader.loadDomDiff();">
+					Reload diff
+				</a>
 			</div>
 		</div>
 	</div>
@@ -116,6 +132,13 @@ body {
     	        return "top";
     	    }
     	});
+	</script>
+	<!-- Scripts for diff -->
+	<script>
+		$("document").ready(function() {
+			diffLoader.setupFileInputListeners();
+			diffLoader.updateStateHistoryWithDom("${javascriptDom}");
+		});
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Hi all,

I needed an easy way to visualise the differences between state DOMs after crawling, and the CrawlOverview plugin seemed like a suitable place :)

I therefore added a tab to the "state" pages of the plugin, on which the diff with the previous state is shown. Users can also choose other files manually.

See [my website](http://iplantevin.net/ct/co1/states/index.html) for a simple demo crawl report with the new tab.

I thought I'd share this with you as a pull request on 4.0, see the commit for some more details.

Best regards,

Ivan
