### PR TITLE
Gauge for number of states with candidates

### DIFF
--- a/core/src/main/java/com/crawljax/core/UnfiredCandidateActions.java
+++ b/core/src/main/java/com/crawljax/core/UnfiredCandidateActions.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import com.codahale.metrics.Gauge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +56,12 @@ public class UnfiredCandidateActions {
 		        registry.register(MetricsModule.EVENTS_PREFIX + "crawler_lost", new Counter());
 		unfiredActionsCount =
 		        registry.register(MetricsModule.EVENTS_PREFIX + "unfired_actions", new Counter());
+		registry.register(MetricsModule.EVENTS_PREFIX + "states_with_candidates", new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return statesWithCandidates.size();
+			}
+		});
 	}
 
 	/**


### PR DESCRIPTION
Hi all,

This tiny addition is currently the only difference left between the version of crawljax I use for my project and the current 4.0 branch. It would simplify further development if you merged this :)

The addition is a gauge to get the number of states with candidate actions. I use this to create live graphs of the development of total states and states with candidates over time.

@alexnederlof: have a good time in India, hopefully the coffee gets better..

-- Ivan
