### PR TITLE
fixing test for XMLUnit 1.5 breaking changes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>xmlunit</groupId>
 			<artifactId>xmlunit</artifactId>
-			<version>1.4</version>
+			<version>1.5</version>
 		</dependency>
 
 		<dependency>

--- a/core/src/test/java/com/crawljax/util/DOMComparerTest.java
+++ b/core/src/test/java/com/crawljax/util/DOMComparerTest.java
@@ -43,7 +43,7 @@ public class DOMComparerTest {
 		        "<html><body><header>Crawljax</header><p>There are differences</p></body></html>";
 		String testHTML =
 		        "<html><head><title>Crawljax</title></head><body><p>There are differences.</body></html>";
-		final int EXPECTED_DIFF = 5;
+		final int EXPECTED_DIFF = 7;
 
 		Document control = DomUtils.asDocument(controlHTML);
 		assertNotNull(control);


### PR DESCRIPTION
As per [XMLUnit 1.5 Release notes](http://xmlunit.sourceforge.net/userguide/html/apas05.html), it introduces 2 new differences if one node in the comparison has children while the other one has not.  For control HTML:

``` html
<html><body><header>Crawljax</header><p>There are differences</p></body></html>
```

...and test HTML:

``` html
<html><head><title>Crawljax</title></head><body><p>There are differences.</body></html>
```

... following are the 2 newly added differences apart from old 5:
- `Expected number of child nodes '0' but was '1' - comparing <HEAD...> at /HTML[1]/HEAD[1] to <HEAD...> at /HTML[1]/HEAD[1]` - **CHILD_NODELIST_LENGTH difference**
- `Expected presence of child node 'null' but was 'TITLE' - comparing  at null to <TITLE...> at /HTML[1]/HEAD[1]/TITLE[1]` - **CHILD_NODE_NOT_FOUND difference**
