### PR TITLE
upgrading phantomjsdriver version so that the tests run again agaist Pha...

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -133,9 +133,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.detro.ghostdriver</groupId>
-			<artifactId>phantomjsdriver</artifactId>
-			<version>1.1.0</version>
+  			<groupId>com.codeborne</groupId>
+  			<artifactId>phantomjsdriver</artifactId>
+  			<version>1.2.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>servlet-api-2.5</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,7 @@
 
 		<slf4j.version>1.7.7</slf4j.version>
 		<logback.version>1.1.2</logback.version>
-		<!-- PhantomJS is broken with 2.44.0 <selenium.version>[2.43.0,)</selenium.version> -->
-		<selenium.version>2.43.0</selenium.version> 
+		<selenium.version>[2.44.0,)</selenium.version>
 		<jetty.version>9.1.3.v20140225</jetty.version>
 		<metrics.version>3.0.2</metrics.version>
 	</properties>


### PR DESCRIPTION
Bumped
- phantomjsdriver  to 1.2.1 
- Selenium to 2.44.0

All tests pass with PhantomJS 1.9.8 now. 
