### PR TITLE
Fix/webdriver ssl

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -146,14 +146,14 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 		DesiredCapabilities caps = new DesiredCapabilities();
 		caps.setCapability("takesScreenshot", true);
-		caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[]{"--webdriver-loglevel=WARN", "--ignore-ssl-errors=true", "--ssl-protocol=tlsv1"});
+		caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[]{"--webdriver-loglevel=WARN", "--ignore-ssl-errors=true"});
 		final ProxyConfiguration proxyConf = configuration
 				.getProxyConfiguration();
 		if (proxyConf != null && proxyConf.getType() != ProxyType.NOTHING) {
 			final String proxyAddrCap = "--proxy=" + proxyConf.getHostname()
 					+ ":" + proxyConf.getPort();
 			final String proxyTypeCap = "--proxy-type=http";
-			final String[] args = new String[] { proxyAddrCap, proxyTypeCap, "--ssl-protocol=tlsv1", "--ignore-ssl-errors=true"};
+			final String[] args = new String[] { proxyAddrCap, proxyTypeCap, "--ignore-ssl-errors=true"};
 			caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, args);
 		}
 		

--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -102,6 +102,10 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 			        .getHostname());
 			profile.setPreference("network.proxy.http_port", configuration
 			        .getProxyConfiguration().getPort());
+			profile.setPreference("network.proxy.ssl", configuration.getProxyConfiguration()
+					.getHostname());
+			profile.setPreference("network.proxy.ssl_port", configuration
+					.getProxyConfiguration().getPort());
 			profile.setPreference("network.proxy.type", configuration.getProxyConfiguration()
 			        .getType().toInt());
 			/* use proxy for everything, including localhost */
@@ -142,14 +146,14 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 		DesiredCapabilities caps = new DesiredCapabilities();
 		caps.setCapability("takesScreenshot", true);
-		caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[]{"--webdriver-loglevel=WARN"});
+		caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[]{"--webdriver-loglevel=WARN", "--ignore-ssl-errors=true", "--ssl-protocol=tlsv1"});
 		final ProxyConfiguration proxyConf = configuration
 				.getProxyConfiguration();
 		if (proxyConf != null && proxyConf.getType() != ProxyType.NOTHING) {
 			final String proxyAddrCap = "--proxy=" + proxyConf.getHostname()
 					+ ":" + proxyConf.getPort();
 			final String proxyTypeCap = "--proxy-type=http";
-			final String[] args = new String[] { proxyAddrCap, proxyTypeCap };
+			final String[] args = new String[] { proxyAddrCap, proxyTypeCap, "--ssl-protocol=tlsv1", "--ignore-ssl-errors=true"};
 			caps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, args);
 		}
 		


### PR DESCRIPTION
When using a man-in-the-middle proxy with crawljax there will be SSL protocol errors. In this case PhantomJS should be started with the argument "--ignore-ssl-errors=true". Maybe you want to add a switch to the configuration to turn off this option again.

There were also missing two preferences for Firefox if it is used with a proxy on an SSL-encrypted website.
