### PR TITLE
Fixed InMemoryStateFlowGraph.getAllPossiblePaths test

### DIFF
--- a/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
@@ -235,7 +235,7 @@ public class StateFlowGraphTest {
                 }
             }
         }
-        assertThat(uEvents.size(), is(8));
+        assertThat(uEvents.size(), is(7));
     }
 
 }

--- a/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateFlowGraphTest.java
@@ -1,26 +1,21 @@
 package com.crawljax.core.state;
 
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import com.crawljax.core.ExitNotifier;
+import com.crawljax.core.state.Eventable.EventType;
+import com.crawljax.core.state.Identification.How;
+import org.jgrapht.GraphPath;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jgrapht.GraphPath;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.crawljax.core.ExitNotifier;
-import com.crawljax.core.state.Eventable.EventType;
-import com.crawljax.core.state.Identification.How;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.*;
 
 public class StateFlowGraphTest {
 
@@ -201,83 +196,46 @@ public class StateFlowGraphTest {
 		assertThat(graph.getNumberOfStates(), is(2));
 	}
 
-	@Test
-	public void testAllPossiblePaths() {
-		graph.putIfAbsent(state2);
-		graph.putIfAbsent(state3);
-		graph.putIfAbsent(state4);
-		graph.putIfAbsent(state5);
+    @Test
+    public void testAllPossiblePaths() {
+        graph.putIfAbsent(state2);
+        graph.putIfAbsent(state3);
+        graph.putIfAbsent(state4);
+        graph.putIfAbsent(state5);
 
-		graph.addEdge(index, state2, newXpathEventable("/index/2"));
-		graph.addEdge(state2, index, newXpathEventable("/2/index"));
-		graph.addEdge(state2, state3, newXpathEventable("/2/3"));
-		graph.addEdge(index, state4, newXpathEventable("/index/4"));
-		graph.addEdge(state2, state5, newXpathEventable("/2/5"));
-		graph.addEdge(state4, index, newXpathEventable("/4/index"));
-		graph.addEdge(index, state5, newXpathEventable("/index/5"));
-		graph.addEdge(state4, state2, newXpathEventable("/4/2"));
-		graph.addEdge(state3, state5, newXpathEventable("/3/5"));
+        graph.addEdge(index, state2, newXpathEventable("/index/2"));
+        graph.addEdge(state2, index, newXpathEventable("/2/index"));
+        graph.addEdge(state2, state3, newXpathEventable("/2/3"));
+        graph.addEdge(index, state4, newXpathEventable("/index/4"));
+        graph.addEdge(state2, state5, newXpathEventable("/2/5"));
+        graph.addEdge(state4, index, newXpathEventable("/4/index"));
+        graph.addEdge(index, state5, newXpathEventable("/index/5"));
+        graph.addEdge(state4, state2, newXpathEventable("/4/2"));
+        graph.addEdge(state3, state5, newXpathEventable("/3/5"));
+        graph.addEdge(state3, state4, newXpathEventable("/3/4"));
 
-		graph.addEdge(state3, state4, newXpathEventable("/3/4"));
+        List<List<GraphPath<StateVertex, Eventable>>> results = graph.getAllPossiblePaths(index);
 
-		List<List<GraphPath<StateVertex, Eventable>>> results = graph.getAllPossiblePaths(index);
+        assertThat(results, hasSize(2));
 
-		assertEquals(2, results.size());
+        assertThat(results.get(0), hasSize(5));
 
-		List<GraphPath<StateVertex, Eventable>> p = results.get(0);
+        assertThat(results.get(0).get(0).getEdgeList(), hasSize(1));
 
-		assertEquals(5, p.size());
+        assertThat(results.get(1), hasSize(2));
 
-		GraphPath<StateVertex, Eventable> e = p.get(0);
+        Set<Eventable> uEvents = new HashSet<>();
+        for (List<GraphPath<StateVertex, Eventable>> paths : results) {
+            for (GraphPath<StateVertex, Eventable> p : paths) {
+                for (Eventable edge : p.getEdgeList()) {
+                    if (!uEvents.contains(edge)) {
+                        uEvents.add(edge);
+                    }
 
-		assertEquals(1, e.getEdgeList().size());
-
-		p = results.get(1);
-
-		assertEquals(2, p.size());
-
-	}
-
-	@Test
-	public void largetTest() {
-		graph.putIfAbsent(state2);
-		graph.putIfAbsent(state3);
-		graph.putIfAbsent(state4);
-		graph.putIfAbsent(state5);
-
-		graph.addEdge(index, state2, newXpathEventable("/index/2"));
-		graph.addEdge(state2, index, newXpathEventable("/2/index"));
-		graph.addEdge(state2, state3, newXpathEventable("/2/3"));
-		graph.addEdge(index, state4, newXpathEventable("/index/4"));
-		graph.addEdge(state2, state5, newXpathEventable("/2/5"));
-		graph.addEdge(state4, index, newXpathEventable("/4/index"));
-		graph.addEdge(index, state5, newXpathEventable("/index/5"));
-		graph.addEdge(state4, state2, newXpathEventable("/4/2"));
-		graph.addEdge(state3, state5, newXpathEventable("/3/5"));
-
-		List<List<GraphPath<StateVertex, Eventable>>> results = graph.getAllPossiblePaths(index);
-
-		assertThat(results, hasSize(2));
-
-		assertThat(results.get(0), hasSize(5));
-
-		assertThat(results.get(0).get(0).getEdgeList(), hasSize(1));
-
-		assertThat(results.get(1), hasSize(2));
-		// int max = 0;
-		Set<Eventable> uEvents = new HashSet<>();
-
-		for (List<GraphPath<StateVertex, Eventable>> paths : results) {
-			for (GraphPath<StateVertex, Eventable> p : paths) {
-				// int z = 0;
-				for (Eventable edge : p.getEdgeList()) {
-					if (!uEvents.contains(edge)) {
-						uEvents.add(edge);
-					}
-
-				}
-			}
-		}
-	}
+                }
+            }
+        }
+        assertThat(uEvents.size(), is(8));
+    }
 
 }


### PR DESCRIPTION
'largetTest' was missing an edge to pass one of the assertions. Generation of 'uEvents' also didn't make sense in the test method. I've consolidated 'largetTest' into 'testAllPossiblePaths' and added the missing check for 'uEvents'.