### PR TITLE
Prefer consistency over concurrency for stateById map

### DIFF
--- a/core/src/main/java/com/crawljax/core/state/InMemoryStateFlowGraph.java
+++ b/core/src/main/java/com/crawljax/core/state/InMemoryStateFlowGraph.java
@@ -4,10 +4,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -50,7 +47,8 @@ public class InMemoryStateFlowGraph implements Serializable, StateFlowGraph {
 	 */
 	private final AtomicInteger stateCounter = new AtomicInteger();
 	private final AtomicInteger nextStateNameCounter = new AtomicInteger();
-	private final ConcurrentMap<Integer, StateVertex> stateById;
+	private final Map<Integer, StateVertex> stateById;
+
 	private final ExitNotifier exitNotifier;
 	private final StateVertexFactory vertexFactory;
 
@@ -65,7 +63,7 @@ public class InMemoryStateFlowGraph implements Serializable, StateFlowGraph {
 		this.exitNotifier = exitNotifier;
 		this.vertexFactory = vertexFactory;
 		sfg = new DirectedMultigraph<>(Eventable.class);
-		stateById = Maps.newConcurrentMap();
+		stateById = Collections.synchronizedMap(new HashMap<Integer, StateVertex>());
 		LOG.debug("Initialized the stateflowgraph");
 		ReadWriteLock lock = new ReentrantReadWriteLock();
 		readLock = lock.readLock();


### PR DESCRIPTION
The data structure used in InMemoryStateFlowGraph should not sacrifice consistency over concurrency. Guava's MapMaker JavaDoc states that "The bulk operations putAll, equals, and clear are not guaranteed to be performed atomically on the returned map. Additionally, size and containsValue are implemented as bulk read operations, and thus may fail to observe concurrent writes."