### PR TITLE
Update Apache Commons Validator dependecy. Fixes #474

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
-			<version>1.4.0</version>
+			<version>1.4.1</version>
 		</dependency>
 
 

--- a/cli/src/test/java/com/crawljax/cli/JarRunnerTest.java
+++ b/cli/src/test/java/com/crawljax/cli/JarRunnerTest.java
@@ -174,7 +174,19 @@ public class JarRunnerTest {
 		                .getCrawlRules();
 		assertThat(crawlRules.getWaitAfterEvent(), is(123L));
 	}
-
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void whenInvalidTLDItFails() {
+		String[] args = { "http://test.invaliddomain", tmpFolder.getRoot().getPath() };
+		new JarRunner(args);
+	}
+	
+	@Test
+	public void testRecentTLD() {
+		String[] args = { "http://test.today", tmpFolder.getRoot().getPath() };
+		new JarRunner(args);
+	}
+	
 	@After
 	public void after() {
 		assertThat(streams.getErrorOutput(), isEmptyString());


### PR DESCRIPTION
Crawljax currently uses Apache Commons Validator 1.4.0
This commit updates it to latest version (1.4.1), which
was updated with a more recent TLD list.

https://issues.apache.org/jira/browse/VALIDATOR-348

All tests still passing.