### PR TITLE
[Overview-plugin] Fix broken link

### DIFF
--- a/plugins/crawloverview-plugin/src/main/resources/index.html
+++ b/plugins/crawloverview-plugin/src/main/resources/index.html
@@ -186,14 +186,28 @@ footer small {
 								}
 							});
 
-					$('.navbar li').click(function(e) {
-						$('.navbar li').removeClass('active');
-						var $this = $(this);
-						if (!$this.hasClass('active')) {
-							$this.addClass('active');
-						}
+					/* Makes nav links update the nav toolback with current page */
+					$('.nav-link').click(function(e) { 
+						/* Example: #url */
+						var target = e.target.hash;
 
+						updateNav(target);
 					});
+
+					/* page: a string with target page, like "#nav" */
+					function updateNav(page) {
+						/* Removes active class from previous active link */
+						$('.navbar li').removeClass('active');
+
+						/* Find correct link on nav-bar and add active class to it */
+						$('.navbar li').each(function(index, element) {
+							if ($(element).find('a').get(0).hash === page) {
+								$(element).addClass('active');
+
+								return false;
+							}
+						});
+					}
 
 					function loadPage(page) {
 						$('.page').hide();

--- a/plugins/crawloverview-plugin/src/main/resources/nav.html
+++ b/plugins/crawloverview-plugin/src/main/resources/nav.html
@@ -7,13 +7,13 @@
 				<a class="brand" href="#">Crawl overview</a>
 			#end
 			<ul class="nav">
-				#if($page == "state") 
-					<li class="active" ><a href="#">State inspector</a></li>
+				#if($page == "state")
+					<li class="active"><a href="#">State inspector</a></li>
 				#else
-					<li class="active"><a href="#graph">State graph</a></li>
-					<li><a href="#statistics">Statistics</a></li>
-					<li><a href="#urls">URL's</a></li>
-					<li><a href="#config">Configuration</a></li>
+					<li class="active"><a href="#graph" class="nav-link">State graph</a></li>
+					<li><a href="#statistics" class="nav-link">Statistics</a></li>
+					<li><a href="#urls" class="nav-link">URL's</a></li>
+					<li><a href="#config" class="nav-link">Configuration</a></li>
 				#end
 			</ul>
 			<div class="nav pull-right">

--- a/plugins/crawloverview-plugin/src/main/resources/statistics.html
+++ b/plugins/crawloverview-plugin/src/main/resources/statistics.html
@@ -17,7 +17,7 @@
 				<td>${stats.stateStats.totalNumberOfStates}</td>
 			</tr>
 			<tr>
-				<th><a href="urls.html">URL's visited</a></th>
+				<th><a href="#urls" class="nav-link">URL's visited</a></th>
 				<td>${stats.stateStats.urls.keySet().size()}</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
On "Statistics" tab, there was a broken link ("URL's Visited") to the "URL" tab

![crawljax broken link](https://cloud.githubusercontent.com/assets/196840/8444322/47a6c21e-1f44-11e5-9588-65ade713be9b.png)

Some javascript changes had to be made in order to fix this bug

There was a javascript function being used to update the
"active" element on the nav bar. This function was being
triggered by elements on the nav bar itself, so I had to
update the CSS selector from ".navbar li" to my own
selector ".nav-link" in order to be able to have nav links
outside the nav bar