### PR TITLE
[Web] Fix system locale-dependent test case

### DIFF
--- a/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
+++ b/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
@@ -298,7 +298,7 @@ public class StandardFunctionsFlowTest {
 		        "//td[preceding-sibling::td[contains(a,'" + CONFIG_NAME + "')]]"));
 		assertNotNull(dateContainer);
 		String displayedDate = dateContainer.getText();
-		SimpleDateFormat dateParser = new SimpleDateFormat("EEE MMM d yyyy HH:mm:ss");
+		SimpleDateFormat dateParser = new SimpleDateFormat("EEE MMM dd yyyy HH:mm:ss", Locale.ENGLISH);
 		Date date = null;
 		try {
 			date = dateParser.parse(displayedDate);


### PR DESCRIPTION
SimpleDateFormat(String pattern) is system locale-dependent. This causes this test to fail on my Windows 8, which is in Portuguese. We should instead use SimpleDateFormat(String pattern, Locale locale), as the crawljax-web is always in English.