### PR TITLE
Corrected the dummy-plugin.jar URL in the StandardFunctionsFlowTest.

### DIFF
--- a/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
+++ b/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
@@ -51,7 +51,7 @@ public class StandardFunctionsFlowTest {
 
 	private static String REMOTE_PLUGIN_NAME = "dummy-plugin";
 	private static String REMOTE_PLUGIN_URL =
-	        "https://raw.github.com/crawljax/crawljax/web-ui-with-plugins/web/src/test/resources/dummy-plugin.jar";
+	        "https://raw.githubusercontent.com/crawljax/crawljax/master/web/src/test/resources/dummy-plugin.jar";
 
 	@Rule
 	public TestRule globalTimeout = new Timeout(120 * 1000);


### PR DESCRIPTION
The master build was failing on the StandardFunctionsFlowTest.

```
Running com.crawljax.web.jaxrs.StandardFunctionsFlowTest
[qtp1822383117-17] ERROR com.crawljax.web.fs.PluginManager - java.io.FileNotFoundException: https://raw.githubusercontent.com/crawljax/crawljax/web-ui-with-plugins/web/src/test/resources/dummy-plugin.jar
[qtp1822383117-17] ERROR com.crawljax.web.fs.PluginManager - Could not load plugin descriptor in dummy-plugin.jar. 
[qtp1822383117-17] ERROR com.crawljax.web.fs.PluginManager - Could not load plugin dummy-plugin.jar
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 65.872 sec <<< FAILURE! - in com.crawljax.web.jaxrs.StandardFunctionsFlowTest
```

I updated the url to: `https://raw.githubusercontent.com/crawljax/crawljax/master/web/src/test/resources/dummy-plugin.jar`

After this change, the build succeeds.
