### PR TITLE
Restore exclusion of integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -203,6 +203,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- <parallel>methods</parallel> <threadCount>4</threadCount> -->
+                    <excludedGroups>${tests.exclude}</excludedGroups>
                     <systemPropertyVariables>
                         <test.browser>${test.browser}</test.browser>
                     </systemPropertyVariables>

--- a/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
+++ b/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
@@ -14,12 +14,10 @@ import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.StateVertex;
 import com.crawljax.metrics.MetricsModule;
-import com.crawljax.test.BrowserTest;
 import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -34,7 +32,6 @@ import static org.mockito.Mockito.*;
 /**
  * Test cases to test the running and correct functioning of the plugins. Used to address issue #26
  */
-@Category(BrowserTest.class)
 @RunWith(MockitoJUnitRunner.class)
 public class PluginsTest {
 

--- a/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
@@ -7,14 +7,17 @@ import com.crawljax.core.CrawljaxRunner;
 import com.crawljax.core.ExitNotifier;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.test.BrowserTest;
 import com.crawljax.test.RunWithWebServer;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+@Category(BrowserTest.class)
 public class StateVertexFactoryTest {
 
 	@ClassRule

--- a/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
@@ -3,9 +3,11 @@ package com.crawljax.core.state;
 import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BaseCrawler;
+import com.crawljax.test.BrowserTest;
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Set;
 
@@ -14,6 +16,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
+@Category(BrowserTest.class)
 public class StatesContainElementsTest {
 
 	private CrawlSession crawl;

--- a/core/src/test/java/com/crawljax/test/SimpleCrawlTest.java
+++ b/core/src/test/java/com/crawljax/test/SimpleCrawlTest.java
@@ -5,11 +5,13 @@ import com.crawljax.core.state.StateFlowGraph;
 import com.crawljax.forms.FormInputValueHelper;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasEdges;
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
 import static org.junit.Assert.assertThat;
 
+@Category(BrowserTest.class)
 public abstract class SimpleCrawlTest {
 
 	private CrawlSession crawl;


### PR DESCRIPTION
Restore the exclusion of integration tests in the default profile (the
exclusion was removed accidentally(?) in a previous change
734c89df5591356f22090015b8c40f015fb20705).
Also, correct browser test tagging, remove it from a test that does not
use the browser and add it to tests that do use.