### PR TITLE
Use StringBuilder whenever possible

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/ConfigurationHelper.java
+++ b/core/src/main/java/com/crawljax/core/configuration/ConfigurationHelper.java
@@ -17,7 +17,7 @@ public final class ConfigurationHelper {
 	 * @return string representation of list. format: a, b, , c. Empty String allowed
 	 */
 	public static String listToStringEmptyStringAllowed(List<String> items) {
-		StringBuffer str = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		int i = 0;
 		for (String item : items) {
 			if (i > 0) {
@@ -34,7 +34,7 @@ public final class ConfigurationHelper {
 	 * @return string representation of list. format: a, b, c
 	 */
 	public static String listToString(List<?> items) {
-		StringBuffer str = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		for (Object item : items) {
 			if (!str.toString().equals("")) {
 				str.append(", ");

--- a/core/src/main/java/com/crawljax/forms/RandomInputValueGenerator.java
+++ b/core/src/main/java/com/crawljax/forms/RandomInputValueGenerator.java
@@ -20,13 +20,13 @@ public class RandomInputValueGenerator {
 	 * @return a random string
 	 */
 	private String generate(int length) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		for (int i = 0; i < length; i++) {
 			int index = new Random().nextInt(
 					"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".length());
-			buf.append("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", index, index + 1);
+			str.append("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", index, index + 1);
 		}
-		return buf.toString();
+		return str.toString();
 	}
 
 	/**

--- a/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
@@ -106,7 +106,7 @@ public class StyleComparator extends AbstractComparator {
 		String[] styleProperties = styleAttribute.split(";");
 		String[] styleProperty;
 		String badWayOfDoingThis = "";
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder strBuilder = new StringBuilder();
 
 		for (int i = 0; i < styleProperties.length; i++) {
 			styleProperty = styleProperties[i].split(":");
@@ -115,10 +115,10 @@ public class StyleComparator extends AbstractComparator {
 					if (styleProperty[0].trim().equalsIgnoreCase(ALLOW_STYLE_TYPES[j])) {
 						badWayOfDoingThis +=
 								styleProperty[0].trim() + ": " + styleProperty[1].trim() + ";";
-						buffer.append(styleProperty[0].trim());
-						buffer.append(": ");
-						buffer.append(styleProperty[1].trim());
-						buffer.append(";");
+						strBuilder.append(styleProperty[0].trim());
+						strBuilder.append(": ");
+						strBuilder.append(styleProperty[1].trim());
+						strBuilder.append(";");
 					}
 				}
 			}

--- a/core/src/main/java/com/crawljax/util/XPathHelper.java
+++ b/core/src/main/java/com/crawljax/util/XPathHelper.java
@@ -55,14 +55,14 @@ public final class XPathHelper {
 			return xPath;
 		}
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder strBuilder = new StringBuilder();
 
 		if (parent != node) {
-			buffer.append(getXPathExpression(parent));
-			buffer.append("/");
+			strBuilder.append(getXPathExpression(parent));
+			strBuilder.append("/");
 		}
 
-		buffer.append(node.getNodeName());
+		strBuilder.append(node.getNodeName());
 
 		List<Node> mySiblings = getSiblings(parent, node);
 
@@ -70,12 +70,12 @@ public final class XPathHelper {
 			Node el = mySiblings.get(i);
 
 			if (el.equals(node)) {
-				buffer.append('[').append(Integer.toString(i + 1)).append(']');
+				strBuilder.append('[').append(Integer.toString(i + 1)).append(']');
 				// Found so break;
 				break;
 			}
 		}
-		String xPath = buffer.toString();
+		String xPath = strBuilder.toString();
 		node.setUserData(FULL_XPATH_CACHE, xPath, null);
 		return xPath;
 	}


### PR DESCRIPTION
Replace usage of `StringBuffer` with `StringBuilder` where the
synchronisation of the former is not required (and rename the variables
to match the new object).