### PR TITLE
Improve regex of choosing candidate elements

### DIFF
--- a/core/src/main/java/com/crawljax/core/CandidateElementExtractor.java
+++ b/core/src/main/java/com/crawljax/core/CandidateElementExtractor.java
@@ -331,7 +331,7 @@ public class CandidateElementExtractor {
 	 * @return true if href has the pdf or ps pattern.
 	 */
 	private boolean isFileForDownloading(String href) {
-		final Pattern p = Pattern.compile(".+.pdf|.+.ps|.+.zip|.+.mp3");
+		final Pattern p = Pattern.compile(".+\\.(?:pdf|ps|zip|mp3)(?:$|\\?.+)");
 		return p.matcher(href).matches();
 	}
 

--- a/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
+++ b/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
@@ -159,10 +159,35 @@ public class CandidateElementExtractorTest {
 		assertThat(extract, hasSize(3));
 	}
 
+	@Test
+	public void testExtractShouldIgnoreDownloadFiles() throws Exception {
+		CrawljaxConfigurationBuilder builder =
+				CrawljaxConfiguration.builderFor("http://example.com");
+		builder.crawlRules().click("a");
+		CrawljaxConfiguration config = builder.build();
+
+		CandidateElementExtractor extractor = newElementExtractor(config);
+
+		String file = "/candidateElementExtractorTest/domWithFourTypeDownloadLink.html";
+		List<CandidateElement> candidates = extractFromTestFile(extractor, file);
+
+		for (CandidateElement e : candidates) {
+			LOG.debug("candidate: {}", e.getUniqueString());
+		}
+
+		assertNotNull(candidates);
+		assertEquals(12, candidates.size());
+	}
+
 	private List<CandidateElement> extractFromTestFile(CandidateElementExtractor extractor)
 			throws URISyntaxException {
-		StateVertex currentState = Mockito.mock(StateVertex.class);
 		String file = "/candidateElementExtractorTest/domWithOneExternalAndTwoInternal.html";
+		return extractFromTestFile(extractor, file);
+	}
+
+	private List<CandidateElement> extractFromTestFile(CandidateElementExtractor extractor, String file)
+			throws URISyntaxException {
+		StateVertex currentState = Mockito.mock(StateVertex.class);
 		URL dom = Resources.getResource(getClass(), file);
 		browser.goToUrl(dom.toURI());
 		return extractor.extract(currentState);

--- a/core/src/test/resources/candidateElementExtractorTest/domWithFourTypeDownloadLink.html
+++ b/core/src/test/resources/candidateElementExtractorTest/domWithFourTypeDownloadLink.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+<title>Simple page</title>
+</head>
+<body>
+	<!-- Should be added to candidates -->
+	<a href="/search?a.pdfShop.com"></a>
+	<a href="/search?a.psShop.com"></a>
+	<a href="/search?a.zipShop.com"></a>
+	<a href="/search?a.mp3Shop.com"></a>
+
+	<a href="/pdf"></a>
+	<a href="/ps"></a>
+	<a href="/zip"></a>
+	<a href="/mp3"></a>
+
+	<a href="/abcpdf"></a>
+	<a href="/abcps"></a>
+	<a href="/abczip"></a>
+	<a href="/abcmp3"></a>
+
+	<!-- Should not be added to candidates -->
+	<a href="/abc.pdf"></a>
+	<a href="/abc.ps"></a>
+	<a href="/abc.zip"></a>
+	<a href="/abc.mp3"></a>
+
+	<a href="/abc.pdf?foo=abc"></a>
+	<a href="/abc.ps?foo=abc"></a>
+	<a href="/abc.zip?foo=abc"></a>
+	<a href="/abc.mp3?foo=abc"></a>
+</body>
+</html>


### PR DESCRIPTION
Escape the dot before the file extension to only match the dot.
Use a non-capturing group for the extensions to avoid duplicating the conditions.
Check for file extensions before the query component not just at the end of the URL.

---
Downstream change: zaproxy/crawljax#76.