### PR TITLE
Delete temporary test files

### DIFF
--- a/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
@@ -39,6 +39,7 @@ public class CrawljaxConfigurationBuilderTest {
   @Test(expected = IllegalArgumentException.class)
   public void ifOutputIsFileNotFolderReject() throws Exception {
     File file = File.createTempFile(getClass().getSimpleName(), "tmp");
+    file.deleteOnExit();
     assertThat(file.exists(), is(true));
     testBuilder().setOutputDirectory(file).build();
   }

--- a/core/src/test/java/com/crawljax/util/DomUtilsTest.java
+++ b/core/src/test/java/com/crawljax/util/DomUtilsTest.java
@@ -203,6 +203,7 @@ public class DomUtilsTest {
   @Test
   public void writeAndGetContents() throws IOException, TransformerException {
     File f = File.createTempFile("HelperTest.writeAndGetContents", ".tmp");
+    f.deleteOnExit();
     DomUtils.writeDocumentToFile(
         DomUtils.asDocument("<html><body><p>Test</p></body></html>"),
         f.getAbsolutePath(), "html", 2);


### PR DESCRIPTION
Change `CrawljaxConfigurationBuilderTest` and `DomUtilsTest` to delete the temporary test files when no longer needed (on JVM exit).

---
Downstream change: zaproxy/crawljax#32.