### PR TITLE
Allow to specify a crawl scope

### DIFF
--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -3,6 +3,7 @@ package com.crawljax.core;
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.condition.browserwaiter.WaitConditionChecker;
 import com.crawljax.core.configuration.CrawlRules;
+import com.crawljax.core.configuration.CrawlScope;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.plugin.Plugins;
 import com.crawljax.core.state.CrawlPath;
@@ -69,6 +70,7 @@ public class Crawler {
   private final StateComparator stateComparator;
   private final URI url;
   private final URI basicAuthUrl;
+  private final CrawlScope crawlScope;
   private final Plugins plugins;
   private final FormHandler formHandler;
   private final CrawlRules crawlRules;
@@ -113,6 +115,7 @@ public class Crawler {
     this.browser = context.getBrowser();
     this.url = config.getUrl();
     this.basicAuthUrl = config.getBasicAuthUrl();
+    this.crawlScope = config.getCrawlScope();
     this.plugins = plugins;
     this.crawlRules = config.getCrawlRules();
     this.maxDepth = config.getMaximumDepth();
@@ -834,9 +837,9 @@ public class Crawler {
       Eventable clickable) {
     browser.handlePopups();
     if (fireEvent(clickable, true)) {
-      if (crawlerLeftDomain()) {
+      if (crawlerNotInScope()) {
         throw new StateUnreachableException(targetState,
-            "Domain left while following path");
+            "Domain/scope left while following path");
       }
       int depth = crawlDepth.incrementAndGet();
       LOG.info("Crawl depth is now {}", depth);
@@ -1185,7 +1188,7 @@ public class Crawler {
         action = candidateActionCache.pollActionOrNull(stateMachine.getCurrentState());
       }
       interrupted = Thread.interrupted();
-      if (!interrupted && crawlerLeftDomain()) {
+      if (!interrupted && crawlerNotInScope()) {
         /*
          * It's okay to have left the domain because the action didn't complete due to an
          * interruption.
@@ -1279,7 +1282,7 @@ public class Crawler {
           afterBacktrack);
 //			}
       interrupted = Thread.interrupted();
-      if (!interrupted && crawlerLeftDomain()) {
+      if (!interrupted && crawlerNotInScope()) {
         /*
          * It's okay to have left the domain because the action didn't complete due to an
          * interruption.
@@ -1325,8 +1328,8 @@ public class Crawler {
 
   boolean inspectNewState(Eventable event) {
     browser.handlePopups();
-    if (crawlerLeftDomain()) {
-      LOG.debug("The browser left the domain. Going back one state...");
+    if (crawlerNotInScope()) {
+      LOG.debug("The browser left the domain/scope. Going back one state...");
       goBackOneState();
       return false;
     } else {
@@ -1428,8 +1431,8 @@ public class Crawler {
     }
   }
 
-  private boolean crawlerLeftDomain() {
-    return !UrlUtils.isSameDomain(browser.getCurrentUrl(), url);
+  private boolean crawlerNotInScope() {
+    return !crawlScope.isInScope(browser.getCurrentUrl());
   }
 
   private long parseWaitTimeOrReturnDefault(Matcher m) {

--- a/core/src/main/java/com/crawljax/core/CrawlerLeftDomainException.java
+++ b/core/src/main/java/com/crawljax/core/CrawlerLeftDomainException.java
@@ -1,13 +1,13 @@
 package com.crawljax.core;
 
 /**
- * Is thrown when the browser leaves the domain while crawling.
+ * Is thrown when the browser leaves the domain/scope while crawling.
  */
 @SuppressWarnings("serial")
 public class CrawlerLeftDomainException extends CrawljaxException {
 
   public CrawlerLeftDomainException(String currentUrl) {
-    super("Somehow we left the domain to " + currentUrl);
+    super("Somehow we left the domain/scope to " + currentUrl);
   }
 
 }

--- a/core/src/main/java/com/crawljax/core/configuration/CrawlScope.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawlScope.java
@@ -1,0 +1,23 @@
+package com.crawljax.core.configuration;
+
+/**
+ * The crawl scope allows to check if a URL is or not in scope.
+ *
+ * <p>URLs in scope are crawled during the crawling process.
+ *
+ * @since 5.0
+ */
+@FunctionalInterface
+public interface CrawlScope {
+
+  /**
+   * Tells whether or not the given URL is in scope.
+   *
+   * <p>Called during the crawl process, to know if the crawling process should crawl or backtrack.
+   *
+   * @param url the URL to check if it's in scope.
+   * @return {@code true} if the given URL is in scope, {@code false} otherwise.
+   */
+  boolean isInScope(String url);
+}
+

--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -32,6 +32,7 @@ public class CrawljaxConfiguration {
 
   private URI url;
   private URI basicAuthUrl;
+  private CrawlScope crawlScope;
   private BrowserConfiguration browserConfig =
       new BrowserConfiguration(BrowserType.FIREFOX, 1, new BrowserOptions(true));
   private ImmutableList<Plugin> plugins;
@@ -78,6 +79,10 @@ public class CrawljaxConfiguration {
 
   public URI getBasicAuthUrl() {
     return basicAuthUrl;
+  }
+
+  public CrawlScope getCrawlScope() {
+    return crawlScope;
   }
 
   public BrowserConfiguration getBrowserConfig() {
@@ -168,7 +173,7 @@ public class CrawljaxConfiguration {
   @Override
   public int hashCode() {
     return Objects.hashCode(url, browserConfig, plugins, proxyConfiguration, crawlRules,
-        maximumStates, maximumRuntime, maximumDepth);
+        crawlScope, maximumStates, maximumRuntime, maximumDepth);
   }
 
   @Override
@@ -180,6 +185,7 @@ public class CrawljaxConfiguration {
           && Objects.equal(this.plugins, that.plugins)
           && Objects.equal(this.proxyConfiguration, that.proxyConfiguration)
           && Objects.equal(this.crawlRules, that.crawlRules)
+          && Objects.equal(this.crawlScope, that.crawlScope)
           && Objects.equal(this.maximumStates, that.maximumStates)
           && Objects.equal(this.maximumRuntime, that.maximumRuntime)
           && Objects.equal(this.maximumDepth, that.maximumDepth);
@@ -193,7 +199,7 @@ public class CrawljaxConfiguration {
         .add("browserConfig", browserConfig).add("plugins", plugins)
         .add("proxyConfiguration", proxyConfiguration).add("crawlRules", crawlRules)
         .add("maximumStates", maximumStates).add("maximumRuntime", maximumRuntime)
-        .add("maximumDepth", maximumDepth).toString();
+        .add("maximumDepth", maximumDepth).add("crawlScope", crawlScope).toString();
   }
 
   public static class CrawljaxConfigurationBuilder {
@@ -226,6 +232,20 @@ public class CrawljaxConfiguration {
           URI.create(config.url.toString().replaceFirst("://", "://" + hostPrefix));
 
       return this;
+    }
+
+    /**
+     * Sets the crawl scope.
+     *
+     * <p>If {@code null}, then a {@link DefaultCrawlScope} is used.
+     *
+     * @param crawlScope the crawl scope
+     * @return this {@code CrawljaxConfigurationBuilder} for method chaining.
+     * @since 5.0
+     */
+    public CrawljaxConfigurationBuilder setCrawlScope(CrawlScope crawlScope) {
+       config.crawlScope = crawlScope;
+       return this;
     }
 
     /**
@@ -386,6 +406,10 @@ public class CrawljaxConfiguration {
 
       config.plugins = pluginBuilder.build();
       config.crawlRules = crawlRules.build();
+
+      if (config.crawlScope == null) {
+        config.crawlScope = new DefaultCrawlScope(config.getUrl());
+      }
 
       // If Clickable detection is enabled, make sure CDP is enabled.
       for (Plugin plugin : config.plugins) {

--- a/core/src/main/java/com/crawljax/core/configuration/DefaultCrawlScope.java
+++ b/core/src/main/java/com/crawljax/core/configuration/DefaultCrawlScope.java
@@ -1,0 +1,61 @@
+package com.crawljax.core.configuration;
+
+import java.net.URI;
+
+import com.crawljax.util.UrlUtils;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+/**
+ * A {@link CrawlScope} that allows to crawl only under a given domain.
+ *
+ * @since 5.0
+ */
+public class DefaultCrawlScope implements CrawlScope {
+
+  private URI url;
+
+  /**
+   * Constructs a {@code DefaultCrawlScope} with the given URL.
+   *
+   * @param url the URL with allowed domain, must not be {@code null}.
+   */
+  public DefaultCrawlScope(URI url) {
+    Preconditions.checkNotNull(url);
+    this.url = url;
+  }
+
+  /**
+   * Gets the URL used for scope check.
+   *
+   * @return the URL used for scope check.
+   */
+  public URI getUrl() {
+    return url;
+  }
+
+  @Override
+  public boolean isInScope(String url) {
+    return UrlUtils.isSameDomain(url, this.url);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(url);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof DefaultCrawlScope) {
+      DefaultCrawlScope that = (DefaultCrawlScope) object;
+      return Objects.equal(this.url, that.url);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("url", url).toString();
+  }
+}

--- a/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
@@ -2,6 +2,7 @@ package com.crawljax.core.configuration;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import java.io.File;
@@ -58,6 +59,20 @@ public class CrawljaxConfigurationBuilderTest {
             .build();
     assertThat(conf.getBasicAuthUrl().toString(),
         Is.is("https://username:password@example.com/test/?a=b#anchor"));
+  }
+
+  @Test
+  public void shouldReturnDefaultCrawlScopeIfNoneSet() throws Exception {
+    CrawlScope crawlScope = testBuilder().build().getCrawlScope();
+    assertThat(crawlScope, is(instanceOf(DefaultCrawlScope.class)));
+    assertThat(((DefaultCrawlScope) crawlScope).getUrl().toString(), is("http://localhost"));
+  }
+
+  @Test
+  public void shouldReturnCrawlScopeSet() throws Exception {
+    CrawlScope crawlScope = url -> true;
+    CrawljaxConfiguration conf = testBuilder().setCrawlScope(crawlScope).build();
+    assertThat(conf.getCrawlScope(), is(crawlScope));
   }
 
 }

--- a/core/src/test/java/com/crawljax/core/configuration/DefaultCrawlScopeTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/DefaultCrawlScopeTest.java
@@ -1,0 +1,29 @@
+package com.crawljax.core.configuration;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class DefaultCrawlScopeTest {
+
+  private static final URI SEED = URI.create("http://localhost/");
+
+  @Test(expected = NullPointerException.class)
+  public void nullSeedDomainIsNotAllowed() throws Exception {
+    new DefaultCrawlScope((URI) null);
+  }
+
+  @Test
+  public void defaultCrawlScopeShouldIncludeSeedDomain() throws Exception {
+    CrawlScope defaultCrawlScope = new DefaultCrawlScope(SEED);
+    assertThat(defaultCrawlScope.isInScope("http://localhost/in/scope"), is(true));
+  }
+
+  @Test
+  public void defaultCrawlScopeShouldNotIncludeNonSeedDomain() throws Exception {
+    CrawlScope defaultCrawlScope = new DefaultCrawlScope(SEED);
+    assertThat(defaultCrawlScope.isInScope("http://example.com/not/in/scope"), is(false));
+  }
+}

--- a/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
+++ b/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
@@ -1,0 +1,52 @@
+package com.crawljax.crawls;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.crawljax.core.CrawlSession;
+import com.crawljax.core.configuration.CrawlScope;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+import com.crawljax.core.state.StateVertex;
+import com.crawljax.test.BaseCrawler;
+import com.crawljax.test.BrowserTest;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(BrowserTest.class)
+public class CrawlWithCustomScopeTest {
+
+  @Test
+  public void crawlsPagesOnlyInCustomScope() throws Exception {
+    CrawlScope crawlScope =
+            url -> url.contains("in_scope") || url.endsWith("crawlscope/index.html");
+    BaseCrawler baseCrawler =
+        new BaseCrawler("crawlscope") {
+          @Override
+          public CrawljaxConfigurationBuilder newCrawlConfigurationBuilder() {
+            CrawljaxConfigurationBuilder builder = super.newCrawlConfigurationBuilder();
+            builder.setCrawlScope(crawlScope);
+            return builder;
+          }
+        };
+
+    CrawlSession crawlSession = baseCrawler.crawl();
+
+    URI baseUrl = baseCrawler.getWebServer().getSiteUrl();
+    Set<String> crawledUrls = new HashSet<>();
+    for (StateVertex state : crawlSession.getStateFlowGraph().getAllStates()) {
+      crawledUrls.add(state.getUrl());
+    }
+
+    assertThat(
+        crawledUrls,
+        hasItems(
+            baseUrl + "crawlscope",
+            baseUrl + "crawlscope/in_scope.html",
+            baseUrl + "crawlscope/in_scope_inner.html"));
+    assertThat(crawledUrls.size(), is(3));
+  }
+}

--- a/core/src/test/resources/site/crawlscope/in_scope.html
+++ b/core/src/test/resources/site/crawlscope/in_scope.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>In Scope</title>
+</head>
+<body>
+	<h1>In Scope</h1>
+	<p>This page can be accessed and crawled.</p>
+	<a href="in_scope_inner.html">inner page</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/in_scope_inner.html
+++ b/core/src/test/resources/site/crawlscope/in_scope_inner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>In Scope Inner Page</title>
+</head>
+<body>
+	<h1>In Scope Inner Page</h1>
+	<p>This page should be accessed.</p>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/index.html
+++ b/core/src/test/resources/site/crawlscope/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Index Scope Test</title>
+</head>
+<body>
+	<h1>Index Scope Test</h1>
+	<p>Pages that are in and out of crawl scope.</p>
+	<a href="out_of_scope.html">out of scope</a>
+	<a href="in_scope.html">in scope</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/out_of_scope.html
+++ b/core/src/test/resources/site/crawlscope/out_of_scope.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Out of Scope</title>
+</head>
+<body>
+	<h1>Out of Scope</h1>
+	<p>This page can be accessed but not crawled.</p>
+	<a href="out_of_scope_inner.html">inner page</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/out_of_scope_inner.html
+++ b/core/src/test/resources/site/crawlscope/out_of_scope_inner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Out of Scope Inner Page</title>
+</head>
+<body>
+	<h1>Out of Scope Inner Page</h1>
+	<p>This page should not be accessed.</p>
+</body>
+</html>

--- a/examples/src/main/java/com/crawljax/examples/CrawlScopeExample.java
+++ b/examples/src/main/java/com/crawljax/examples/CrawlScopeExample.java
@@ -1,0 +1,22 @@
+package com.crawljax.examples;
+
+import com.crawljax.core.CrawljaxRunner;
+import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+
+/** Example of running Crawljax with a custom crawl scope. */
+public final class CrawlScopeExample {
+
+  private static final String URL = "http://example.com/";
+
+  /** Run this method to start the crawl. */
+  public static void main(String[] args) {
+    CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(URL);
+
+    // Don't allow to crawl subdomains (default scope crawls subdomains).
+    builder.setCrawlScope(url -> url.startsWith(URL));
+
+    CrawljaxRunner crawljax = new CrawljaxRunner(builder.build());
+    crawljax.call();
+  }
+}


### PR DESCRIPTION
Allow to control which of the URLs accessed can be crawled, for example, to allow to crawl several domains or just some pages under a given domain.

---
Downstream change: zaproxy/crawljax#5.