### PR TITLE
Use specified browser in (all) browser tests

### DIFF
--- a/core/src/test/java/com/crawljax/core/IFrameTest.java
+++ b/core/src/test/java/com/crawljax/core/IFrameTest.java
@@ -29,8 +29,8 @@ public class IFrameTest {
   protected CrawljaxRunner crawljax;
 
   protected CrawljaxConfigurationBuilder setupConfig() {
-    CrawljaxConfigurationBuilder builder =
-        CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl().resolve("iframe"));
+    CrawljaxConfigurationBuilder builder = WEB_SERVER.newConfigBuilder("iframe");
+    // Note: Tests fail with Chrome, use Firefox always.
     builder.setBrowserConfig(
         new BrowserConfiguration(EmbeddedBrowser.BrowserType.FIREFOX_HEADLESS));
 

--- a/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
+++ b/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
@@ -3,6 +3,8 @@ package com.crawljax.core;
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.crawljax.browser.BrowserProvider;
+import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BrowserTest;
@@ -72,6 +74,7 @@ public class PassBasicHttpAuthTest {
     CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(url);
     builder.setMaximumStates(3);
     builder.setBasicAuth(USERNAME, PASSWORD);
+    builder.setBrowserConfig(new BrowserConfiguration(BrowserProvider.getBrowserType()));
     CrawlSession session = new CrawljaxRunner(builder.build()).call();
 
     assertThat(session.getStateFlowGraph(), hasStates(3));

--- a/core/src/test/java/com/crawljax/core/PopUpTest.java
+++ b/core/src/test/java/com/crawljax/core/PopUpTest.java
@@ -23,9 +23,7 @@ public class PopUpTest {
 
   @Test
   public void testPopups() throws CrawljaxException {
-    CrawljaxConfigurationBuilder builder =
-        CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl().resolve("popup"));
-    builder.setBrowserConfig(new BrowserConfiguration(BrowserProvider.getBrowserType()));
+    CrawljaxConfigurationBuilder builder = WEB_SERVER.newConfigBuilder("popup");
     builder.setMaximumDepth(3);
     builder.crawlRules().click("a");
     builder.crawlRules().waitAfterEvent(100, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Change `PassBasicHttpAuthTest` to use the specified browser.
Change `IFrameTest` and `PopUpTest` to use the base method that sets the expected browser.
Add note to `IFrameTest` that it fails with Chrome.

---
Related downstream changes: zaproxy/crawljax#9.