### PR TITLE
Log with parameterized messages

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
@@ -463,7 +463,7 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
       boolean result = false;
 
       if (eventable.getRelatedFrame() != null && !eventable.getRelatedFrame().equals("")) {
-        LOGGER.debug("switching to frame: " + eventable.getRelatedFrame());
+        LOGGER.debug("switching to frame: {}", eventable.getRelatedFrame());
         try {
 
           switchToFrame(eventable.getRelatedFrame());
@@ -665,11 +665,11 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 
       String handle = browser.getWindowHandle();
 
-      LOGGER.debug("The current H: " + handle);
+      LOGGER.debug("The current H: {}", handle);
       try {
         switchToFrame(frameIdentification);
       } catch (InvalidSelectorException e) {
-        LOGGER.info("Invalid frame selector: " + frameIdentification + ", continuing...");
+        LOGGER.info("Invalid frame selector: {}, continuing...", frameIdentification);
         LOGGER.debug(e.getMessage(), e);
         browser.switchTo().defaultContent();
         return;
@@ -683,7 +683,7 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 
       String toAppend = browser.getPageSource();
 
-      LOGGER.debug("frame dom: " + toAppend);
+      LOGGER.debug("frame dom: {}", toAppend);
 
       browser.switchTo().defaultContent();
 
@@ -694,20 +694,20 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 
         appendFrameContent(importedElement, document, frameIdentification);
       } catch (DOMException | IOException e) {
-        LOGGER.info("Got exception while inspecting a frame:" + frameIdentification
-            + " continuing...", e);
+        LOGGER.info(
+            "Got exception while inspecting a frame: {} continuing...", frameIdentification, e);
       }
     }
   }
 
   private void switchToFrame(String frameIdentification) throws NoSuchFrameException {
-    LOGGER.debug("frame identification: " + frameIdentification);
+    LOGGER.debug("frame identification: {}", frameIdentification);
 
     if (frameIdentification.contains(".")) {
       String[] frames = frameIdentification.split("\\.");
 
       for (String frameId : frames) {
-        LOGGER.debug("switching to frame: " + frameId);
+        LOGGER.debug("switching to frame: {}", frameId);
         browser.switchTo().frame(frameId);
       }
 
@@ -814,7 +814,7 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
     try {
       switchToFrame(iframeIdentification);
     } catch (InvalidSelectorException e) {
-      LOGGER.warn("Invalid frame selector: " + iframeIdentification + ", continuing...");
+      LOGGER.warn("Invalid frame selector: {}, continuing...", iframeIdentification);
       LOGGER.debug(e.getMessage(), e);
       browser.switchTo().defaultContent();
       return "";

--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -80,7 +80,7 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
               + configuration.getBrowserConfig().getBrowserType());
       }
     } catch (IllegalStateException e) {
-      LOGGER.error("Crawling with {} failed: " + e.getMessage(), browserType);
+      LOGGER.error("Crawling with {} failed: {}", browserType, e.getMessage());
       throw e;
     }
 

--- a/core/src/main/java/com/crawljax/condition/browserwaiter/WaitCondition.java
+++ b/core/src/main/java/com/crawljax/condition/browserwaiter/WaitCondition.java
@@ -76,12 +76,12 @@ public class WaitCondition {
     List<ExpectedCondition> toCheckWaitConditions = new ArrayList<>(expectedConditions);
     long currentTime = System.currentTimeMillis();
     long maxTime = currentTime + this.timeOut;
-    LOGGER.info("Waiting for " + toCheckWaitConditions.size() + " conditions");
+    LOGGER.info("Waiting for {} conditions", toCheckWaitConditions.size());
     int index = 0;
     while (index < toCheckWaitConditions.size() && currentTime <= maxTime) {
       ExpectedCondition checkCondition = toCheckWaitConditions.get(index);
       lastCheckCondition = checkCondition;
-      LOGGER.debug("Waiting for: " + checkCondition);
+      LOGGER.debug("Waiting for: {}", checkCondition);
       if (checkCondition.isSatisfied(browser)) {
         index++;
       } else {
@@ -95,8 +95,10 @@ public class WaitCondition {
       currentTime = System.currentTimeMillis();
     }
     if (currentTime >= maxTime) {
-      LOGGER.info("TIMEOUT WaitCondition url " + getUrl() + "; Timeout while waiting for "
-          + lastCheckCondition);
+      LOGGER.info(
+          "TIMEOUT WaitCondition url {}; Timeout while waiting for {}",
+          getUrl(),
+          lastCheckCondition);
       return 0;
     } else {
       return 1;

--- a/core/src/main/java/com/crawljax/condition/browserwaiter/WaitConditionChecker.java
+++ b/core/src/main/java/com/crawljax/condition/browserwaiter/WaitConditionChecker.java
@@ -40,7 +40,7 @@ public class WaitConditionChecker {
       return;
     }
     for (WaitCondition waitCondition : waitConditions) {
-      LOGGER.info("Checking WaitCondition for url: " + waitCondition.getUrl());
+      LOGGER.info("Checking WaitCondition for url: {}", waitCondition.getUrl());
       waitCondition.testAndWait(browser);
     }
   }

--- a/core/src/main/java/com/crawljax/forms/FormHandler.java
+++ b/core/src/main/java/com/crawljax/forms/FormHandler.java
@@ -248,7 +248,7 @@ public class FormHandler {
       Document dom = DomUtils.asDocument(browser.getStrippedDomWithoutIframeContent());
       for (FormInput input : formInputs) {
         failing = input;
-        LOGGER.info("resetting : " + input.getIdentification().getValue());
+        LOGGER.info("resetting : {}", input.getIdentification().getValue());
         resetInputElementValue(formInputValueHelper.getBelongingNode(input, dom), input);
         handled.add(input);
         failing = null;
@@ -323,7 +323,7 @@ public class FormHandler {
       Document dom = DomUtils.asDocument(browser.getStrippedDomWithoutIframeContent());
       for (FormInput input : formInputs) {
         failing = input;
-        LOGGER.info("Filling in: " + input.getIdentification().getValue());
+        LOGGER.info("Filling in: {}", input.getIdentification().getValue());
         Node belongingNode = formInputValueHelper.getBelongingNode(input, dom);
         setInputElementValue(belongingNode, input);
         if (belongingNode != null) {

--- a/core/src/main/java/com/crawljax/forms/FormInputValueHelper.java
+++ b/core/src/main/java/com/crawljax/forms/FormInputValueHelper.java
@@ -107,7 +107,7 @@ public final class FormInputValueHelper {
     String serialized = json.toJson(instance.formInputs.values());
 
     try {
-      LOGGER.info("Writing training form inputs to " + out);
+      LOGGER.info("Writing training form inputs to {}", out);
       FileUtils.writeStringToFile(out, serialized, Charset.defaultCharset());
     } catch (IOException e) {
       LOGGER.error(e.getMessage(), e);
@@ -128,7 +128,7 @@ public final class FormInputValueHelper {
     final File in = new File(dir, FORMS_JSON_FILE);
 
     if (in.exists()) {
-      LOGGER.info("Reading trained form inputs from " + in.getAbsolutePath());
+      LOGGER.info("Reading trained form inputs from {}", in.getAbsolutePath());
       Gson gson = new GsonBuilder().create();
 
       try {
@@ -170,8 +170,8 @@ public final class FormInputValueHelper {
     int maxValues = getMaxNumberOfValues(eventableCondition.getLinkedInputFields());
 
     if (maxValues == EMPTY) {
-      LOGGER.warn("No input values found for element: "
-          + DomUtils.getElementString(sourceElement));
+      LOGGER.warn(
+          "No input values found for element: {}", DomUtils.getElementString(sourceElement));
       return candidateElements;
     }
 
@@ -190,10 +190,10 @@ public final class FormInputValueHelper {
                   getFormInputWithIndexValue(browser, element, curValueIndex);
               formInputsForCurrentIndex.add(formInput);
             } else {
-              LOGGER.warn("Could not find input element for: " + input);
+              LOGGER.warn("Could not find input element for: {}", input);
             }
           } catch (XPathExpressionException e) {
-            LOGGER.warn("Could not find input element for: " + input);
+            LOGGER.warn("Could not find input element for: {}", input);
             LOGGER.error(e.getMessage(), e);
           }
         }
@@ -251,8 +251,8 @@ public final class FormInputValueHelper {
         break;
 
       default:
-        LOGGER.info("Identification " + input.getIdentification()
-            + " not supported yet for form inputs.");
+        LOGGER.info(
+            "Identification {} not supported yet for form inputs.", input.getIdentification());
         break;
 
     }

--- a/core/src/main/java/com/crawljax/oraclecomparator/StateComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/StateComparator.java
@@ -58,7 +58,7 @@ public class StateComparator {
   private boolean allPreConditionsSucceed(OracleComparator oraclePreCondition,
       EmbeddedBrowser browser) {
     for (Condition preCondition : oraclePreCondition.getPreConditions()) {
-      LOGGER.debug("Check precondition: " + preCondition.toString());
+      LOGGER.debug("Check precondition: {}", preCondition);
       if (!preCondition.check(browser)) {
         return false;
       }

--- a/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
@@ -83,7 +83,7 @@ public class StyleComparator extends AbstractComparator {
           parent.removeChild(removeNode);
         }
       } catch (XPathExpressionException | DOMException e) {
-        LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+        LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
         LOGGER.error(e.getMessage(), e);
       }
     }
@@ -100,7 +100,7 @@ public class StyleComparator extends AbstractComparator {
           attributes.removeNamedItem(attribute);
         }
       } catch (XPathExpressionException | DOMException e) {
-        LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+        LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
       }
     }
     return dom;

--- a/core/src/main/java/com/crawljax/oraclecomparator/comparators/XPathExpressionComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/comparators/XPathExpressionComparator.java
@@ -66,7 +66,7 @@ public class XPathExpressionComparator extends AbstractComparator {
         }
       }
     } catch (XPathExpressionException | DOMException | IOException e) {
-      LOGGER.error("Exception with stripping XPath expression: " + curExpression, e);
+      LOGGER.error("Exception with stripping XPath expression: {}", curExpression, e);
     } finally {
       if (doc != null) {
         domRet = DomUtils.getDocumentToString(doc);

--- a/core/src/main/java/com/crawljax/util/DomUtils.java
+++ b/core/src/main/java/com/crawljax/util/DomUtils.java
@@ -220,7 +220,7 @@ public final class DomUtils {
             xpath);
       }
     } catch (XPathExpressionException e) {
-      LOGGER.error("Error while removing tag " + xpath, e);
+      LOGGER.error("Error while removing tag {}", xpath, e);
     }
 
     return dom;
@@ -251,7 +251,7 @@ public final class DomUtils {
             "//" + tagName.toUpperCase());
       }
     } catch (XPathExpressionException e) {
-      LOGGER.error("Error while removing tag " + tagName, e);
+      LOGGER.error("Error while removing tag {}", tagName, e);
     }
 
     return dom;
@@ -375,7 +375,7 @@ public final class DomUtils {
 
       return dd.getAllDifferences();
     } catch (IOException e) {
-      LOGGER.error("Error with getDifferences: " + e.getMessage(), e);
+      LOGGER.error("Error with getDifferences: {}", e.getMessage(), e);
     }
     return null;
   }

--- a/core/src/main/java/com/crawljax/util/ElementResolver.java
+++ b/core/src/main/java/com/crawljax/util/ElementResolver.java
@@ -77,7 +77,7 @@ public class ElementResolver {
           XPathHelper.evaluateXpathExpression(dom, "//"
               + eventable.getElement().getTag().toUpperCase());
       if (logging) {
-        LOGGER.info("Candidates: " + candidateElements.getLength());
+        LOGGER.info("Candidates: {}", candidateElements.getLength());
       }
       for (int i = 0; i < candidateElements.getLength(); i++) {
         Element candidateElement = new Element(candidateElements.item(i));


### PR DESCRIPTION
Change log statements to use parameterized messages (instead of string concatenations), to avoid unnecessary work when the message is not actually logged.

---
Downstream changes: zaproxy/crawljax#18.