### PR TITLE
Terminate WebDrivers, always

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawlTaskConsumer.java
+++ b/core/src/main/java/com/crawljax/core/CrawlTaskConsumer.java
@@ -44,13 +44,17 @@ public class CrawlTaskConsumer implements Callable<Void> {
                 pollAndHandleCrawlTasks();
                 runningConsumers.decrementAndGet();
             }
-            crawler.close();
         } catch (InterruptedException e) {
             LOG.debug("Consumer interrupted");
-            crawler.close();
         } catch (RuntimeException e) {
             LOG.error("Unexpected error " + e.getMessage(), e);
             throw e;
+        } finally {
+            try {
+                crawler.close();
+            } catch (Exception e) {
+                LOG.error("Error occurred while closing the browser:", e);
+            }
         }
         return null;
     }


### PR DESCRIPTION
Change `CrawlTaskConsumer` to always close the crawler, in a finally block.
Change `WebDriverBackedEmbeddedBrowser` to close/quit the browser in a different thread than the one being called to avoid interruptions, which could prevent the WebDriver (e.g. chromedriver, geckodriver) from being terminated, leading to process leaks.
Quit the browser directly instead of using WebDriverManager when it does not contain any as the WebDriver might not have been created through it (e.g. when using custom `Provider<EmbeddedBrowser>`).

---
Downstream change: zaproxy/crawljax#20.

---
Sample exception when failed to quit the WebDriver because of the interrupt:
```
NettyWebSocket initial request interrupted
java.lang.InterruptedException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:385)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at org.openqa.selenium.remote.http.netty.NettyWebSocket.<init>(NettyWebSocket.java:99)
	at org.openqa.selenium.remote.http.netty.NettyWebSocket.lambda$create$3(NettyWebSocket.java:128)
	at org.openqa.selenium.remote.http.netty.NettyClient.openSocket(NettyClient.java:107)
	at org.openqa.selenium.devtools.Connection.<init>(Connection.java:78)
	at org.openqa.selenium.firefox.FirefoxDriver.maybeGetDevTools(FirefoxDriver.java:269)
	at org.openqa.selenium.remote.RemoteWebDriver.quit(RemoteWebDriver.java:438)
	at org.openqa.selenium.firefox.FirefoxDriver.quit(FirefoxDriver.java:323)
…
```
which prevents both WebDriver and browser to quit.