### PR TITLE
Ensure executor is shutdown on error

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawlController.java
+++ b/core/src/main/java/com/crawljax/core/CrawlController.java
@@ -75,14 +75,20 @@ public class CrawlController implements Callable<CrawlSession> {
      */
     @Override
     public CrawlSession call() {
-        setMaximumCrawlTimeIfNeeded();
-        plugins.runPreCrawlingPlugins(config);
-        CrawlTaskConsumer firstConsumer = consumerFactory.get();
-        StateVertex firstState = firstConsumer.crawlIndex();
-        crawlSessionProvider.setup(firstState, firstConsumer);
-        //		plugins.runOnNewStatePlugins(firstConsumer.getContext(), firstState);
-        executeConsumers(firstConsumer);
-        return crawlSessionProvider.get();
+        try {
+            setMaximumCrawlTimeIfNeeded();
+            plugins.runPreCrawlingPlugins(config);
+            CrawlTaskConsumer firstConsumer = consumerFactory.get();
+            StateVertex firstState = firstConsumer.crawlIndex();
+            crawlSessionProvider.setup(firstState, firstConsumer);
+            // plugins.runOnNewStatePlugins(firstConsumer.getContext(), firstState);
+            executeConsumers(firstConsumer);
+            return crawlSessionProvider.get();
+        } finally {
+            if (!executor.isShutdown()) {
+                executor.shutdownNow();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Change `CrawlController` to shutdown the executor (if not already) in a finally block to ensure it's shutdown even in case of error calling the `consumerfactory` (e.g. error starting the browser).

Part of zaproxy/zaproxy#7138.