### PR TITLE
Allow to opt out of output directory

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawljaxRunner.java
+++ b/core/src/main/java/com/crawljax/core/CrawljaxRunner.java
@@ -11,6 +11,7 @@ import com.crawljax.forms.FormInput;
 import com.crawljax.forms.FormInputValueHelper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import java.io.File;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -33,7 +34,12 @@ public class CrawljaxRunner implements Callable<CrawlSession> {
      * Reads input data from a JSON file in the output directory.
      */
     private void readFormDataFromFile() {
-        List<FormInput> formInputList = FormInputValueHelper.deserializeFormInputs(config.getSiteDir());
+        File siteDir = config.getSiteDir();
+        if (siteDir == null) {
+            return;
+        }
+
+        List<FormInput> formInputList = FormInputValueHelper.deserializeFormInputs(siteDir);
 
         if (formInputList != null) {
             InputSpecification inputSpecs = config.getCrawlRules().getInputSpecification();

--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -116,6 +116,9 @@ public class CrawljaxConfiguration {
      * @return The output directory for site-specific data such as form inputs.
      */
     public File getSiteDir() {
+        if (output == null) {
+            return null;
+        }
 
         // If we've already created the folder, return it.
         if (siteOutput != null) {
@@ -139,6 +142,9 @@ public class CrawljaxConfiguration {
      * @return The output directory for crawl-specific data such as crawl-overview output.
      */
     public File getOutputDir() {
+        if (output == null) {
+            return null;
+        }
 
         // If we've already created the folder, return it.
         if (pluginOutput != null) {
@@ -389,7 +395,9 @@ public class CrawljaxConfiguration {
          */
         public CrawljaxConfigurationBuilder setOutputDirectory(File output) {
             config.output = output;
-            checkOutputDirWritable();
+            if (config.output != null) {
+                checkOutputDirWritable();
+            }
             return this;
         }
 
@@ -416,6 +424,10 @@ public class CrawljaxConfiguration {
 
             if (config.crawlScope == null) {
                 config.crawlScope = new DefaultCrawlScope(config.getUrl());
+            }
+
+            if (!config.plugins.isEmpty() && config.output == null) {
+                throw new IllegalArgumentException("The output directory should be specified when using plugins.");
             }
 
             // If Clickable detection is enabled, make sure CDP is enabled.

--- a/core/src/main/java/com/crawljax/core/plugin/Plugins.java
+++ b/core/src/main/java/com/crawljax/core/plugin/Plugins.java
@@ -60,7 +60,9 @@ public class Plugins {
         Preconditions.checkNotNull(plugins);
         ImmutableListMultimap.Builder<Class<? extends Plugin>, Plugin> builder = ImmutableListMultimap.builder();
         if (plugins.isEmpty()) {
-            LOGGER.warn("No plugins loaded. There will be no output");
+            if (config.getOutputDir() != null) {
+                LOGGER.warn("No plugins loaded. There will be no output");
+            }
         } else {
             addPlugins(plugins, builder);
         }

--- a/core/src/main/java/com/crawljax/fragmentation/FragmentationPlugin.java
+++ b/core/src/main/java/com/crawljax/fragmentation/FragmentationPlugin.java
@@ -212,6 +212,9 @@ public class FragmentationPlugin implements OnNewStatePlugin, OnRevisitStatePlug
 
     public static void writeCrawlPath(CrawlSession session, CrawlPath crawlPath, int id) {
         File outputDir = session.getConfig().getOutputDir();
+        if (outputDir == null) {
+            return;
+        }
 
         GsonBuilder builder = new GsonBuilder();
         Gson gson = builder.setPrettyPrinting().create();


### PR DESCRIPTION
Do not require an output directory when not using plugins, to avoid creating directories/output when not wanted/needed. Update "core" methods that expected an output directory to not try read and write any data.
Also, do not log a warn when not using plugins nor an output directory.