### PR TITLE
Ensure new browsers have page loaded

### DIFF
--- a/core/src/main/java/com/crawljax/core/Crawler.java
+++ b/core/src/main/java/com/crawljax/core/Crawler.java
@@ -386,6 +386,10 @@ public class Crawler {
             if (crawlpath == null) {
                 crawlpath = new CrawlPath(stateMachine.getCurrentState().getId());
             }
+            // New browser, without the page open yet.
+            if (!url.toASCIIString().equals(browser.getCurrentUrl())) {
+                browser.goToUrl(url);
+            }
         }
         try {
             if (crawlTask.getId() == stateMachine.getCurrentState().getId()) {


### PR DESCRIPTION
It could happen that a new browser was open to crawl a new state but the page was not accessed beforehand leading to, e.g.:
```
Eventable element is not valid: Unable to locate element: /X/Y/Z[1]
```
and causing the crawler to miss states.